### PR TITLE
sks ta: fix handle database against spectre issue

### DIFF
--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1472,23 +1472,25 @@ TEE_Result TEE_AEEncryptFinal(TEE_OperationHandle operation,
 	 * Check that required destLen is big enough before starting to feed
 	 * data to the algorithm. Errors during feeding of data are fatal as we
 	 * can't restore sync with this API.
+	 *
+	 * Need to check this before update_payload since sync would be lost if
+	 * we return short buffer after that.
 	 */
+	res = TEE_ERROR_GENERIC;
+
 	req_dlen = operation->buffer_offs + srcLen;
 	if (*destLen < req_dlen) {
 		*destLen = req_dlen;
 		res = TEE_ERROR_SHORT_BUFFER;
-		goto out;
 	}
 
-	/*
-	 * Need to check this before update_payload since sync would be lost if
-	 * we return short buffer after that.
-	 */
 	if (*tagLen < operation->ae_tag_len) {
 		*tagLen = operation->ae_tag_len;
 		res = TEE_ERROR_SHORT_BUFFER;
-		goto out;
 	}
+
+	if (res == TEE_ERROR_SHORT_BUFFER)
+		goto out;
 
 	tl = *tagLen;
 	tmp_dlen = *destLen - acc_dlen;

--- a/lib/libutils/isoc/arch/arm/sanitize_array_index.S
+++ b/lib/libutils/isoc/arch/arm/sanitize_array_index.S
@@ -1,0 +1,49 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2018, Linaro Limited
+ */
+
+#include <asm.S>
+
+#if defined(CFG_UNWIND)
+#define UNWIND(...)	__VA_ARGS__
+#else
+#define UNWIND(...)
+#endif
+
+#ifdef ARM32
+#define SANITY_SHIFT 	31
+
+	.macro return
+		bx	lr
+	.endm
+#endif
+
+#ifdef ARM64
+#define SANITY_SHIFT	63
+
+	.macro return
+		ret
+	.endm
+#endif
+
+	.macro __sanitize_array_signed_index_nospec x0, x1, x2
+		asr	\x2, \x0, #SANITY_SHIFT	/* X2 = (idx < 0) ? ~0 :: 0 */
+		sub	\x1, \x1, \x0		/* X1 is negative if handle > max */
+		asr	\x1, \x1, #SANITY_SHIFT	/* X2 = (idx > max) ? ~0 :: 0 */
+		bics	\x0, \x0, \x1		/* nullify idx if above max */
+		bics	\x0, \x0, \x2		/* nullify idx if idx negative */
+		return
+	.endm
+
+FUNC sanitize_array_signed_index_nospec , :
+UNWIND(	.fnstart)
+#if defined(ARM32)
+	__sanitize_array_signed_index_nospec r0, r1, r2
+#elif defined(ARM64)
+	__sanitize_array_signed_index_nospec x0, x1, x2
+#else
+#error "Expect ARM32 or ARM64 as assembly directive"
+#endif
+UNWIND(	.fnend)
+END_FUNC sanitize_array_signed_index_nospec

--- a/lib/libutils/isoc/arch/arm/sub.mk
+++ b/lib/libutils/isoc/arch/arm/sub.mk
@@ -20,3 +20,5 @@ cflags-arm32_aeabi_softfloat.c-y += -Wno-missing-declarations
 subdirs-$(CFG_ARM32_$(sm)) += softfloat
 endif
 endif
+
+srcs-y += sanitize_array_index.S

--- a/lib/libutils/isoc/include/sanitize_array_index.h
+++ b/lib/libutils/isoc/include/sanitize_array_index.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Linaro Limited
+ */
+#ifndef SANITIZE_ARRAY_SIGNED_INDEX_H
+#define SANITIZE_ARRAY_SIGNED_INDEX_H
+
+#ifndef ASM
+#include <assert.h>
+
+/*
+ * long int sanitize_array_signed_index_nospec(long int index, long int max)
+ *
+ * Return the value of signed index idx or 0 if idx is negative or if
+ * is exceeds value of max. The sequence must execute without
+ * speculatively returning any out of bounds index values.
+ *
+ * Max must be positive.
+ */
+long int sanitize_array_signed_index_nospec(long int index, long int max);
+#endif
+
+#endif /*SANITIZE_ARRAY_SIGNED_INDEX_H*/

--- a/ta_services/secure_key_services/src/handle.c
+++ b/ta_services/secure_key_services/src/handle.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <assert.h>
 #include <stdlib.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>

--- a/ta_services/secure_key_services/src/handle.c
+++ b/ta_services/secure_key_services/src/handle.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
@@ -49,6 +50,10 @@ uint32_t handle_get(struct handle_db *db, void *ptr)
 		new_max_ptrs = db->max_ptrs * 2;
 	else
 		new_max_ptrs = HANDLE_DB_INITIAL_MAX_PTRS;
+
+	if (new_max_ptrs > (UINT32_MAX / 2))
+		return 0;
+
 	p = TEE_Realloc(db->ptrs, new_max_ptrs * sizeof(void *));
 	if (!p)
 		return 0;
@@ -62,22 +67,43 @@ uint32_t handle_get(struct handle_db *db, void *ptr)
 	return n;
 }
 
+/*
+ * Protect from speculative access based on out bound handle values:
+ * Generate a validation mask from signed difference from max valid handle
+ * value to argument handle value:
+ * - out bound handle values generate a null mask.
+ * - handle values that can be seen as negative index generate a null mask.
+ * This scheme expects value 0 is an invalid handle value and should
+ * always return an invalid reference: here always a NULL reference.
+ */
+static size_t guard_handle(struct handle_db *db, uint32_t handle)
+{
+	uint32_t mask_neg = ((int32_t)handle) >> (sizeof(handle) * 8 - 1);
+	uint32_t udiff = db->max_ptrs - handle;
+	int32_t diff = ((int32_t)udiff) >> (sizeof(udiff) * 8 - 1);
+	uint32_t mask_ovf = diff;
+
+	return handle & ~mask_ovf & ~mask_neg;
+}
+
 void *handle_put(struct handle_db *db, uint32_t handle)
 {
+	uint32_t index;
 	void *p;
 
-	if (!db || !handle || handle >= db->max_ptrs)
+	if (!db)
 		return NULL;
 
-	p = db->ptrs[handle];
-	db->ptrs[handle] = NULL;
+	index = guard_handle(db, handle);
+	p = db->ptrs[index];
+	db->ptrs[index] = NULL;
 	return p;
 }
 
 void *handle_lookup(struct handle_db *db, uint32_t handle)
 {
-	if (!db || !handle || handle >= db->max_ptrs)
+	if (!db)
 		return NULL;
 
-	return db->ptrs[handle];
+	return db->ptrs[guard_handle(db, handle)];
 }

--- a/ta_services/secure_key_services/src/handle.h
+++ b/ta_services/secure_key_services/src/handle.h
@@ -8,10 +8,11 @@
 #define __HANDLE_H
 
 #include <stddef.h>
+#include <unistd.h>
 
 struct handle_db {
 	void **ptrs;
-	uint32_t max_ptrs;
+	ssize_t max_ptrs;
 };
 
 #define HANDLE_DB_INITIALIZER { NULL, 0 }
@@ -27,8 +28,8 @@ void handle_db_destroy(struct handle_db *db);
  * Allocates a new handle and assigns the supplied pointer to it,
  * ptr must not be NULL.
  * The function returns
- * >= 0 on success and
- * -1 on failure
+ * > 0 on success and
+ * 0 on failure
  */
 uint32_t handle_get(struct handle_db *db, void *ptr);
 


### PR DESCRIPTION
Caller handle value is processed to generate validation masks so that
invalid handles are force to null value hence treated as invalid
handle argument. The sequence for generating the validation mask
does not rely on conditioned execution that could be bypassed through
exploits on speculative execution.

The sequence is inspired from the Arm64 array_index_mask_nospec macro
recently merged into the Linux kernel.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>