### PR TITLE
SKS: refine token/session/object management

### DIFF
--- a/ta_services/secure_key_services/include/sks_ta.h
+++ b/ta_services/secure_key_services/include/sks_ta.h
@@ -582,7 +582,8 @@ struct sks_attribute_head {
 #define SKS_CKR_OPERATION_ACTIVE		0x0000001a
 #define SKS_CKR_KEY_FUNCTION_NOT_PERMITTED	0x0000001b
 #define SKS_CKR_OPERATION_NOT_INITIALIZED	0x0000001c
-/* Statuc without strict equivalence in cryptoki */
+#define SKS_CKR_TOKEN_WRITE_PROTECTED		0x0000001d
+/* Status without strict equivalence in Cryptoki API */
 #define SKS_NOT_FOUND				0x00001000
 #define SKS_NOT_IMPLEMENTED			0x00001001
 

--- a/ta_services/secure_key_services/src/handle.c
+++ b/ta_services/secure_key_services/src/handle.c
@@ -18,6 +18,11 @@
  */
 #define HANDLE_DB_INITIAL_MAX_PTRS	4
 
+void handle_db_init(struct handle_db *db)
+{
+	TEE_MemFill(db, 0, sizeof(*db));
+}
+
 void handle_db_destroy(struct handle_db *db)
 {
 	if (db) {
@@ -80,4 +85,19 @@ void *handle_lookup(struct handle_db *db, uint32_t handle)
 		return NULL;
 
 	return db->ptrs[handle];
+}
+
+uint32_t handle_lookup_handle(struct handle_db *db, void *ptr)
+{
+	uint32_t n;
+
+	if (ptr) {
+		for (n = 1; n < db->max_ptrs; n++) {
+			if (db->ptrs[n] == ptr) {
+				return n;
+			}
+		}
+	}
+
+	return 0;
 }

--- a/ta_services/secure_key_services/src/handle.h
+++ b/ta_services/secure_key_services/src/handle.h
@@ -17,14 +17,19 @@ struct handle_db {
 #define HANDLE_DB_INITIALIZER { NULL, 0 }
 
 /*
- * Frees all internal data structures of the database, but does not free
+ * Initialize the handle database
+ */
+void handle_db_init(struct handle_db *db);
+
+/*
+ * Free all internal data structures of the database, but does not free
  * the db pointer. The database is safe to reuse after it's destroyed, it
  * just be empty again.
  */
 void handle_db_destroy(struct handle_db *db);
 
 /*
- * Allocates a new handle and assigns the supplied pointer to it,
+ * Allocate a new handle and assigns the supplied pointer to it,
  * ptr must not be NULL.
  * The function returns
  * >= 0 on success and
@@ -33,17 +38,20 @@ void handle_db_destroy(struct handle_db *db);
 uint32_t handle_get(struct handle_db *db, void *ptr);
 
 /*
- * Deallocates a handle. Returns the assiciated pointer of the handle
+ * Deallocate a handle. Returns the assiciated pointer of the handle
  * the the handle was valid or NULL if it's invalid.
  */
 void *handle_put(struct handle_db *db, uint32_t handle);
 
 /*
- * Returns the assiciated pointer of the handle if the handle is a valid
+ * Return the associated pointer of the handle if the handle is a valid
  * handle.
  * Returns NULL on failure.
  */
 void *handle_lookup(struct handle_db *db, uint32_t handle);
+
+/* Return the handle associated to a pointer if found, else return 0 */
+uint32_t handle_lookup_handle(struct handle_db *db, void *ptr);
 
 #endif /*__HANDLE_H*/
 

--- a/ta_services/secure_key_services/src/object.c
+++ b/ta_services/secure_key_services/src/object.c
@@ -473,8 +473,7 @@ uint32_t entry_find_objects_init(uintptr_t teesess, TEE_Param *ctrl,
 	 * FIXME: not clear if C_FindObjects can be called while a processing
 	 * is active. It seems not... but to be confirmed!
 	 */
-	if (check_pkcs_session_processing_state(session,
-						PKCS11_SESSION_READY)) {
+	if (check_processing_state(session, PKCS11_SESSION_READY)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}

--- a/ta_services/secure_key_services/src/object.c
+++ b/ta_services/secure_key_services/src/object.c
@@ -58,8 +58,9 @@ static void cleanup_volatile_obj_ref(struct sks_object *obj)
 	if (obj->key_handle != TEE_HANDLE_NULL)
 		TEE_FreeTransientObject(obj->key_handle);
 
-	if (obj->attribs_hdl != TEE_HANDLE_NULL)
+	if (obj->attribs_hdl != TEE_HANDLE_NULL) {
 		TEE_CloseObject(obj->attribs_hdl);
+	}
 
 	TEE_Free(obj->attributes);
 	TEE_Free(obj->uuid);

--- a/ta_services/secure_key_services/src/object.c
+++ b/ta_services/secure_key_services/src/object.c
@@ -263,7 +263,7 @@ bail:
 	return rv;
 }
 
-uint32_t entry_destroy_object(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_destroy_object(uintptr_t tee_session, TEE_Param *ctrl,
 				TEE_Param *in, TEE_Param *out)
 {
 	struct serialargs ctrlargs;
@@ -286,8 +286,8 @@ uint32_t entry_destroy_object(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	object = sks_handle2object(object_handle, session);
@@ -435,7 +435,7 @@ static void release_find_obj_context(struct pkcs11_find_objects *find_ctx)
 /*
  * Entry for command SKS_CMD_FIND_OBJECTS_INIT
  */
-uint32_t entry_find_objects_init(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_find_objects_init(uintptr_t tee_session, TEE_Param *ctrl,
 				 TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv;
@@ -462,8 +462,8 @@ uint32_t entry_find_objects_init(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess) {
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session) {
 		rv = SKS_CKR_SESSION_HANDLE_INVALID;
 		goto bail;
 	}
@@ -610,7 +610,7 @@ bail:
 /*
  * Entry for command SKS_CMD_FIND_OBJECTS
  */
-uint32_t entry_find_objects(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_find_objects(uintptr_t tee_session, TEE_Param *ctrl,
 			    TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv;
@@ -635,8 +635,8 @@ uint32_t entry_find_objects(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	ctx = session->find_ctx;
@@ -682,7 +682,7 @@ void release_session_find_obj_context(struct pkcs11_session *session)
 /*
  * Entry for command SKS_CMD_FIND_OBJECTS_FINAL
  */
-uint32_t entry_find_objects_final(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_find_objects_final(uintptr_t tee_session, TEE_Param *ctrl,
 				  TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv;
@@ -699,8 +699,8 @@ uint32_t entry_find_objects_final(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	if (!session->find_ctx)

--- a/ta_services/secure_key_services/src/object.h
+++ b/ta_services/secure_key_services/src/object.h
@@ -14,8 +14,6 @@ struct pkcs11_session;
 
 struct sks_object {
 	LIST_ENTRY(sks_object) link;
-	void *session_owner;
-	uint32_t client_handle;
 	/* pointer to the serialized object attributes */
 	void *attributes;
 	TEE_ObjectHandle key_handle;
@@ -28,6 +26,13 @@ LIST_HEAD(object_list, sks_object);
 
 struct sks_object *sks_handle2object(uint32_t client_handle,
 				     struct pkcs11_session *session);
+
+uint32_t sks_object2handle(struct sks_object *obj,
+			   struct pkcs11_session *session);
+
+struct sks_object *create_token_object_instance(struct sks_attrs_head *head,
+						TEE_UUID *uuid);
+
 
 /*
  * create_object - create an SKS object from its attributes and value

--- a/ta_services/secure_key_services/src/persistent_token.c
+++ b/ta_services/secure_key_services/src/persistent_token.c
@@ -120,7 +120,8 @@ uint32_t create_object_uuid(struct ck_token *token __unused,
 {
 	assert(!obj->uuid);
 
-	obj->uuid = TEE_Malloc(sizeof(TEE_UUID), 0);
+	obj->uuid = TEE_Malloc(sizeof(TEE_UUID),
+				TEE_USER_MEM_HINT_NO_FILL_ZERO);
 	if (!obj->uuid)
 		return SKS_MEMORY;
 
@@ -290,8 +291,8 @@ struct ck_token *init_token_db(unsigned int token_id)
 
 	LIST_INIT(&token->object_list);
 
-	db_main = TEE_Malloc(sizeof(*db_main), 0);
-	db_objs = TEE_Malloc(sizeof(*db_objs), 0);
+	db_main = TEE_Malloc(sizeof(*db_main), TEE_MALLOC_FILL_ZERO);
+	db_objs = TEE_Malloc(sizeof(*db_objs), TEE_MALLOC_FILL_ZERO);
 	if (!db_main || !db_objs)
 		goto error;
 

--- a/ta_services/secure_key_services/src/pkcs11_attributes.c
+++ b/ta_services/secure_key_services/src/pkcs11_attributes.c
@@ -486,9 +486,10 @@ uint32_t check_access_attrs_against_token(struct pkcs11_session *session,
 		return SKS_CKR_KEY_FUNCTION_NOT_PERMITTED;
 	}
 
-	switch (session->token->login_state) {
-	case PKCS11_TOKEN_STATE_SECURITY_OFFICER:
-	case PKCS11_TOKEN_STATE_USER_SESSIONS:
+	switch (session->state) {
+	case PKCS11_SESSION_SO_READ_WRITE:
+	case PKCS11_SESSION_USER_READ_WRITE:
+	case PKCS11_SESSION_USER_READ_ONLY:
 		return SKS_OK;
 	default:
 		return SKS_CKR_KEY_FUNCTION_NOT_PERMITTED;

--- a/ta_services/secure_key_services/src/pkcs11_token.c
+++ b/ta_services/secure_key_services/src/pkcs11_token.c
@@ -112,20 +112,24 @@ struct pkcs11_session *sks_handle2session(uint32_t handle)
  * PKCS#11 expects an session must finalize (or cancel) an operation
  * before starting a new one.
  *
- * enum pkcs11_session_processing provides the valid operation states for a
+ * enum pkcs11_proc_state provides the valid operation states for a
  * PKCS#11 session.
  *
- * set_pkcs_session_processing_state() changes the session operation state.
+ * set_processing_state() changes the session operation state.
  *
- * check_pkcs_session_processing_state() checks the session is in the expected
+ * check_processing_state() checks the session is in the expected
  * operation state.
  */
-int set_pkcs_session_processing_state(struct pkcs11_session *pkcs_session,
-				      enum pkcs11_session_processing state)
+int set_processing_state(struct pkcs11_session *pkcs_session,
+			 enum pkcs11_proc_state state)
 {
 	if (!pkcs_session)
 		return 1;
 
+	/*
+	 * Caller can move to any state from the ready state.
+	 * Caller can always return to the ready state.
+	 */
 	if (pkcs_session->processing == PKCS11_SESSION_READY ||
 	    state == PKCS11_SESSION_READY) {
 		pkcs_session->processing = state;
@@ -170,8 +174,8 @@ int set_pkcs_session_processing_state(struct pkcs11_session *pkcs_session,
 	return 1;
 }
 
-int check_pkcs_session_processing_state(struct pkcs11_session *pkcs_session,
-					enum pkcs11_session_processing state)
+int check_processing_state(struct pkcs11_session *pkcs_session,
+			   enum pkcs11_proc_state state)
 {
 	if (!pkcs_session)
 		return 1;

--- a/ta_services/secure_key_services/src/pkcs11_token.c
+++ b/ta_services/secure_key_services/src/pkcs11_token.c
@@ -307,6 +307,10 @@ uint32_t entry_ck_token_initialize(TEE_Param *ctrl,
 	}
 
 	cpin = TEE_Malloc(SKS_TOKEN_PIN_SIZE, TEE_MALLOC_FILL_ZERO);
+	if (!cpin) {
+		return SKS_MEMORY;
+	}
+
 	TEE_MemMove(cpin, pin, pin_size);
 	cipher_pin(token->pin_hdl[0], cpin, SKS_TOKEN_PIN_SIZE);
 
@@ -329,8 +333,7 @@ uint32_t entry_ck_token_initialize(TEE_Param *ctrl,
 	pin_rc = 0;
 	if (token->db_main->so_pin_size != pin_size)
 		pin_rc = 1;
-	if (buf_compare_ct(token->db_main->so_pin, cpin,
-			   SKS_TOKEN_PIN_SIZE))
+	if (buf_compare_ct(token->db_main->so_pin, cpin, SKS_TOKEN_PIN_SIZE))
 		pin_rc = 1;
 
 	if (pin_rc) {
@@ -346,6 +349,7 @@ uint32_t entry_ck_token_initialize(TEE_Param *ctrl,
 				     offsetof(struct token_persistent_main,
 					      flags),
 				     sizeof(token->db_main->flags));
+
 		update_persistent_db(token,
 				     offsetof(struct token_persistent_main,
 					      so_pin_count),
@@ -717,7 +721,6 @@ static uint32_t open_ck_session(uintptr_t tee_session, TEE_Param *ctrl,
 		}
 	}
 
-
 	session = TEE_Malloc(sizeof(*session), 0);
 	if (!session)
 		return SKS_MEMORY;
@@ -749,17 +752,17 @@ static uint32_t open_ck_session(uintptr_t tee_session, TEE_Param *ctrl,
 }
 
 /* ctrl=[slot-id], in=unused, out=[session-handle] */
-uint32_t entry_ck_token_ro_session(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_ck_token_ro_session(uintptr_t tee_session, TEE_Param *ctrl,
 				   TEE_Param *in, TEE_Param *out)
 {
-	return ck_token_session(teesess, ctrl, in, out, true);
+	return open_ck_session(tee_session, ctrl, in, out, true);
 }
 
 /* ctrl=[slot-id], in=unused, out=[session-handle] */
-uint32_t entry_ck_token_rw_session(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_ck_token_rw_session(uintptr_t tee_session, TEE_Param *ctrl,
 				   TEE_Param *in, TEE_Param *out)
 {
-	return ck_token_session(teesess, ctrl, in, out, false);
+	return open_ck_session(tee_session, ctrl, in, out, false);
 }
 
 static void close_ck_session(struct pkcs11_session *session)

--- a/ta_services/secure_key_services/src/pkcs11_token.h
+++ b/ta_services/secure_key_services/src/pkcs11_token.h
@@ -105,8 +105,8 @@ struct token_persistent_objs {
  */
 struct ck_token {
 	enum pkcs11_token_state state;
-	uint32_t session_counter;
-	uint32_t rw_session_counter;
+	uint32_t session_count;
+	uint32_t rw_session_count;
 
 	struct object_list object_list;
 

--- a/ta_services/secure_key_services/src/pkcs11_token.h
+++ b/ta_services/secure_key_services/src/pkcs11_token.h
@@ -108,7 +108,7 @@ struct ck_token {
 	uint32_t session_counter;
 	uint32_t rw_session_counter;
 
-
+	struct object_list object_list;
 
 	TEE_ObjectHandle db_hdl;	/* Opened handle to persistent database */
 	TEE_ObjectHandle pin_hdl[SKS_MAX_USERS];	/* Opened handle to PIN keys */
@@ -187,6 +187,7 @@ struct pkcs11_client {
 struct pkcs11_session {
 	TAILQ_ENTRY(pkcs11_session) link;
 	struct object_list object_list;
+	struct handle_db object_handle_db;
 	struct ck_token *token;
 	uintptr_t tee_session;
 	uint32_t handle;

--- a/ta_services/secure_key_services/src/pkcs11_token.h
+++ b/ta_services/secure_key_services/src/pkcs11_token.h
@@ -123,8 +123,8 @@ struct ck_token {
  * state (from a processing finalization request) before entering another
  * processing state.
  */
-enum pkcs11_session_processing {
-	PKCS11_SESSION_READY = 0,		/* session default state */
+enum pkcs11_proc_state {
+	PKCS11_SESSION_READY = 0,		/* No active processing/operation */
 	PKCS11_SESSION_ENCRYPTING,
 	PKCS11_SESSION_DECRYPTING,
 	PKCS11_SESSION_DIGESTING,
@@ -178,7 +178,7 @@ struct pkcs11_session {
 	uint32_t handle;
 	bool readwrite;
 	uint32_t state;
-	enum pkcs11_session_processing processing;
+	enum pkcs11_proc_state processing;
 	TEE_OperationHandle tee_op_handle;
 	uint32_t proc_id;
 	void *proc_params;
@@ -216,11 +216,12 @@ uint32_t get_persistent_objects_list(struct ck_token *token,
 void ck_token_close_tee_session(uintptr_t tee_session);
 struct pkcs11_session *sks_handle2session(uint32_t client_handle);
 
-int set_pkcs_session_processing_state(struct pkcs11_session *session,
-				      enum pkcs11_session_processing state);
+int set_processing_state(struct pkcs11_session *session,
+			 enum pkcs11_proc_state state);
 
-int check_pkcs_session_processing_state(struct pkcs11_session *session,
-					enum pkcs11_session_processing state);
+/* Return 0 if session state matches , else return 1 */
+int check_processing_state(struct pkcs11_session *session,
+			   enum pkcs11_proc_state state);
 
 bool pkcs11_session_is_read_write(struct pkcs11_session *session);
 

--- a/ta_services/secure_key_services/src/processing.c
+++ b/ta_services/secure_key_services/src/processing.c
@@ -42,7 +42,7 @@ static void release_active_processing(struct pkcs11_session *session)
 		session->tee_op_handle = TEE_HANDLE_NULL;
 	}
 
-	if (set_pkcs_session_processing_state(session, PKCS11_SESSION_READY))
+	if (set_processing_state(session, PKCS11_SESSION_READY))
 		TEE_Panic(0);
 }
 
@@ -87,8 +87,7 @@ uint32_t entry_import_object(uintptr_t teesess,
 		goto bail;
 	}
 
-	if (check_pkcs_session_processing_state(session,
-						PKCS11_SESSION_READY)) {
+	if (check_processing_state(session, PKCS11_SESSION_READY)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}
@@ -389,7 +388,8 @@ static uint32_t load_key(struct sks_object *obj)
 		return rv;
 	}
 
-	if (get_attribute_ptr(obj->attributes, SKS_CKA_VALUE, &value, &value_size))
+	if (get_attribute_ptr(obj->attributes, SKS_CKA_VALUE,
+			      &value, &value_size))
 		TEE_Panic(0);
 
 	res = TEE_AllocateTransientObject(tee_obj_type, value_size * 8,
@@ -455,15 +455,14 @@ uint32_t entry_cipher_init(uintptr_t teesess, TEE_Param *ctrl,
 		goto bail;
 	}
 
-	if (check_pkcs_session_processing_state(session,
-						PKCS11_SESSION_READY)) {
+	if (check_processing_state(session, PKCS11_SESSION_READY)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}
 
-	if (set_pkcs_session_processing_state(session, decrypt ?
-					      PKCS11_SESSION_DECRYPTING :
-					      PKCS11_SESSION_ENCRYPTING)) {
+	if (set_processing_state(session, decrypt ?
+				 PKCS11_SESSION_DECRYPTING :
+				 PKCS11_SESSION_ENCRYPTING)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}
@@ -620,9 +619,9 @@ uint32_t entry_cipher_update(uintptr_t teesess, TEE_Param *ctrl,
 	if (!session || session->tee_session != teesess)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
-	if (check_pkcs_session_processing_state(session, decrypt ?
-						PKCS11_SESSION_DECRYPTING :
-						PKCS11_SESSION_ENCRYPTING))
+	if (check_processing_state(session, decrypt ?
+					    PKCS11_SESSION_DECRYPTING :
+					    PKCS11_SESSION_ENCRYPTING))
 		return SKS_CKR_OPERATION_NOT_INITIALIZED;
 
 	switch (session->proc_id) {
@@ -698,9 +697,9 @@ uint32_t entry_cipher_final(uintptr_t teesess, TEE_Param *ctrl,
 	if (!session || session->tee_session != teesess)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
-	if (check_pkcs_session_processing_state(session, decrypt ?
-						PKCS11_SESSION_DECRYPTING :
-						PKCS11_SESSION_ENCRYPTING))
+	if (check_processing_state(session, decrypt ?
+					    PKCS11_SESSION_DECRYPTING :
+					    PKCS11_SESSION_ENCRYPTING))
 		return SKS_CKR_OPERATION_NOT_INITIALIZED;
 
 	switch (session->proc_id) {
@@ -829,8 +828,7 @@ uint32_t entry_generate_object(uintptr_t teesess,
 		goto bail;
 	}
 
-	if (check_pkcs_session_processing_state(session,
-						PKCS11_SESSION_READY)) {
+	if (check_processing_state(session, PKCS11_SESSION_READY)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}
@@ -949,15 +947,13 @@ uint32_t entry_signverify_init(uintptr_t teesess, TEE_Param *ctrl,
 		goto bail;
 	}
 
-	if (check_pkcs_session_processing_state(session,
-						PKCS11_SESSION_READY)) {
+	if (check_processing_state(session, PKCS11_SESSION_READY)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}
 
-	if (set_pkcs_session_processing_state(session, sign ?
-					      PKCS11_SESSION_SIGNING :
-					      PKCS11_SESSION_VERIFYING)) {
+	if (set_processing_state(session, sign ? PKCS11_SESSION_SIGNING :
+						 PKCS11_SESSION_VERIFYING)) {
 		rv = SKS_CKR_OPERATION_ACTIVE;
 		goto bail;
 	}
@@ -1084,9 +1080,8 @@ uint32_t entry_signverify_update(uintptr_t teesess, TEE_Param *ctrl,
 	if (!session || session->tee_session != teesess)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
-	if (check_pkcs_session_processing_state(session, sign ?
-						PKCS11_SESSION_SIGNING :
-						PKCS11_SESSION_VERIFYING))
+	if (check_processing_state(session, sign ? PKCS11_SESSION_SIGNING :
+						 PKCS11_SESSION_VERIFYING))
 		return SKS_CKR_OPERATION_NOT_INITIALIZED;
 
 	if (!in || out) {
@@ -1150,9 +1145,8 @@ uint32_t entry_signverify_final(uintptr_t teesess, TEE_Param *ctrl,
 	if (!session || session->tee_session != teesess)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
-	if (check_pkcs_session_processing_state(session, sign ?
-						PKCS11_SESSION_SIGNING :
-						PKCS11_SESSION_VERIFYING))
+	if (check_processing_state(session, sign ? PKCS11_SESSION_SIGNING :
+						 PKCS11_SESSION_VERIFYING))
 		return SKS_CKR_OPERATION_NOT_INITIALIZED;
 
 	if (in || !out) {

--- a/ta_services/secure_key_services/src/processing.c
+++ b/ta_services/secure_key_services/src/processing.c
@@ -46,7 +46,7 @@ static void release_active_processing(struct pkcs11_session *session)
 		TEE_Panic(0);
 }
 
-uint32_t entry_import_object(uintptr_t teesess,
+uint32_t entry_import_object(uintptr_t tee_session,
 			     TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv;
@@ -81,8 +81,8 @@ uint32_t entry_import_object(uintptr_t teesess,
 	template_size = sizeof(*template) + template->attrs_size;
 
 	/* Check session/token state against object import */
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess) {
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session) {
 		rv = SKS_CKR_SESSION_HANDLE_INVALID;
 		goto bail;
 	}
@@ -417,7 +417,7 @@ static uint32_t load_key(struct sks_object *obj)
  * in = none
  * out = none
  */
-uint32_t entry_cipher_init(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_cipher_init(uintptr_t tee_session, TEE_Param *ctrl,
 			   TEE_Param *in, TEE_Param *out, int decrypt)
 {
 	uint32_t rv;
@@ -449,8 +449,8 @@ uint32_t entry_cipher_init(uintptr_t teesess, TEE_Param *ctrl,
 	/*
 	 * Check PKCS session (arguments and session state)
 	 */
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess) {
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session) {
 		rv = SKS_CKR_SESSION_HANDLE_INVALID;
 		goto bail;
 	}
@@ -595,7 +595,7 @@ bail:
  * in = data buffer
  * out = data buffer
  */
-uint32_t entry_cipher_update(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_cipher_update(uintptr_t tee_session, TEE_Param *ctrl,
 			     TEE_Param *in, TEE_Param *out, int decrypt)
 {
 	uint32_t rv;
@@ -615,8 +615,8 @@ uint32_t entry_cipher_update(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	if (check_processing_state(session, decrypt ?
@@ -672,7 +672,7 @@ uint32_t entry_cipher_update(uintptr_t teesess, TEE_Param *ctrl,
  * in = none
  * out = data buffer
  */
-uint32_t entry_cipher_final(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_cipher_final(uintptr_t tee_session, TEE_Param *ctrl,
 			    TEE_Param *in, TEE_Param *out, int decrypt)
 {
 	uint32_t rv;
@@ -693,8 +693,8 @@ uint32_t entry_cipher_final(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	if (check_processing_state(session, decrypt ?
@@ -783,7 +783,7 @@ static uint32_t generate_random_key_value(struct sks_attrs_head **head)
 	return rv;
 }
 
-uint32_t entry_generate_object(uintptr_t teesess,
+uint32_t entry_generate_object(uintptr_t tee_session,
 			       TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv;
@@ -822,8 +822,8 @@ uint32_t entry_generate_object(uintptr_t teesess,
 	 * Check arguments
 	 */
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess) {
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session) {
 		rv = SKS_CKR_SESSION_HANDLE_INVALID;
 		goto bail;
 	}
@@ -908,7 +908,7 @@ bail:
  * in = none
  * out = none
  */
-uint32_t entry_signverify_init(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_signverify_init(uintptr_t tee_session, TEE_Param *ctrl,
 				TEE_Param *in, TEE_Param *out, int sign)
 {
 	uint32_t rv;
@@ -941,8 +941,8 @@ uint32_t entry_signverify_init(uintptr_t teesess, TEE_Param *ctrl,
 	 * Check arguments
 	 */
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess) {
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session) {
 		rv = SKS_CKR_SESSION_HANDLE_INVALID;
 		goto bail;
 	}
@@ -1058,7 +1058,7 @@ bail:
  * in = input data
  * out = none
  */
-uint32_t entry_signverify_update(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_signverify_update(uintptr_t tee_session, TEE_Param *ctrl,
 				 TEE_Param *in, TEE_Param *out, int sign)
 {
 	struct serialargs ctrlargs;
@@ -1076,8 +1076,8 @@ uint32_t entry_signverify_update(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	if (check_processing_state(session, sign ? PKCS11_SESSION_SIGNING :
@@ -1122,7 +1122,7 @@ bail:
  * in = none
  * out = data buffer
  */
-uint32_t entry_signverify_final(uintptr_t teesess, TEE_Param *ctrl,
+uint32_t entry_signverify_final(uintptr_t tee_session, TEE_Param *ctrl,
 				TEE_Param *in, TEE_Param *out, int sign)
 {
 	TEE_Result res;
@@ -1141,8 +1141,8 @@ uint32_t entry_signverify_final(uintptr_t teesess, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	session = sks_handle2session(session_handle);
-	if (!session || session->tee_session != teesess)
+	session = sks_handle2session(session_handle, tee_session);
+	if (!session)
 		return SKS_CKR_SESSION_HANDLE_INVALID;
 
 	if (check_processing_state(session, sign ? PKCS11_SESSION_SIGNING :

--- a/ta_services/secure_key_services/src/serializer.c
+++ b/ta_services/secure_key_services/src/serializer.c
@@ -56,7 +56,7 @@ uint32_t serialargs_alloc_and_get(struct serialargs *args,
 		return SKS_BAD_PARAM;
 	}
 
-	ptr = TEE_Malloc(size, 0);
+	ptr = TEE_Malloc(size, TEE_MALLOC_FILL_ZERO);
 	if (!ptr)
 		return SKS_MEMORY;
 


### PR DESCRIPTION
From SKS P-R review (https://github.com/OP-TEE/optee_os/pull/2342#discussion_r195900800) the current implementation is buggy regarding session management and client application identification. It appears also that object ownership management is buggy:
* client applications must own their session over each  token.
* each session must own its object handles
* token can own only the persistent object, and session must manage private object handles for the object it publishes to its client application.

These changes refines client, token, session and object instance and handles management, and few minor fixes. 