### PR TITLE
sks ta: cosmetics: fix typos

### DIFF
--- a/ta/secure_key_services/include/sks_internal_abi.h
+++ b/ta/secure_key_services/include/sks_internal_abi.h
@@ -23,7 +23,7 @@
  * SKS uses a serialized format for defining the attributes of an object. The
  * attributes content starts with a header structure header followed by each
  * attributes, stored in serialized fields:
- * - the 32bit identificator of the attribute
+ * - the 32bit identifier of the attribute
  * - the 32bit value attribute byte size
  * - the effective value of the attribute (variable size)
  */
@@ -38,7 +38,7 @@ struct sks_ref {
  *
  * @attrs_size; byte size of the serialized data
  * @attrs_count; number of items in the blob
- * @class - object class id (from CK litterature): key, certif, etc...
+ * @class - object class id (from CK literature): key, certif, etc...
  * @type - object type id, per class, i.e aes or des3 in the key class.
  * @boolpropl - 32bit bitmask storing boolean properties #0 to #31.
  * @boolproph - 32bit bitmask storing boolean properties #32 to #64.

--- a/ta/secure_key_services/include/sks_ta.h
+++ b/ta/secure_key_services/include/sks_ta.h
@@ -20,7 +20,7 @@
 /*
  * SKS_CMD_PING		Acknowledge TA presence and return TA version info
  *
- * Optinal invocation parameter:
+ * Optional invocation parameter:
  *
  * [out]        memref[2] = [
  *                      32bit version0 value,
@@ -44,7 +44,7 @@
  * SKS_CMD_CK_SLOT_INFO - Get cryptoki structured slot information
  *
  * [in]		memref[0] = 32bit slot ID
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]        memref[2] = (struct sks_ck_slot_info)info
  *
  * The TA instance may represent several PKCS#11 slots and associated tokens.
@@ -77,7 +77,7 @@ struct sks_slot_info {
  * SKS_CMD_CK_TOKEN_INFO - Get cryptoki structured token information
  *
  * [in]		memref[0] = 32bit slot ID
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]        memref[2] = (struct sks_ck_token_info)info
  *
  * The TA instance may represent several PKCS#11 slots and associated tokens.
@@ -139,7 +139,7 @@ struct sks_token_info {
  * SKS_CMD_CK_MECHANISM_IDS - Get list of the supported mechanisms
  *
  * [in]		memref[0] = 32bit slot ID
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]        memref[2] = 32bit array mechanism IDs
  *
  * This commands relates to the PKCS#11 API function C_GetMechanismList.
@@ -153,7 +153,7 @@ struct sks_token_info {
  *			32bit slot ID,
  *			32bit mechanism ID
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]        memref[2] = (struct sks_mecha_info)info
  *
  * This commands relates to the PKCS#11 API function C_GetMechanismInfo.
@@ -199,7 +199,7 @@ struct sks_mechanism_info {
  *			8bit array PIN[PIN length],
  *			8bit array label[32]
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This commands relates to the PKCS#11 API function C_InitToken().
  */
@@ -213,7 +213,7 @@ struct sks_mechanism_info {
  *			32bit PIN length,
  *			8bit array PIN[PIN length]
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This commands relates to the PKCS#11 API function C_InitPIN().
  */
@@ -229,7 +229,7 @@ struct sks_mechanism_info {
  *			32bit new_pin_length,
  *			8bit array new_pin[new_pin_length]
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This commands relates to the PKCS#11 API function C_SetPIN()
  */
@@ -239,7 +239,7 @@ struct sks_mechanism_info {
  * SKS_CMD_CK_OPEN_RO_SESSION - Open read-only session
  *
  * [in]		memref[0] = 32bit slot ID
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[0] = 32bit session handle
  *
  * This commands relates to the PKCS#11 API function C_OpenSession() for a
@@ -251,11 +251,11 @@ struct sks_mechanism_info {
  * SKS_CMD_CK_OPEN_RW_SESSION - Open read/write session
  *
  * [in]		memref[0] = 32bit slot
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[0] = 32bit session handle
  *
  * This commands relates to the PKCS#11 API function C_OpenSession() for a
- * read/Write session.
+ * read/write session.
  */
 #define SKS_CMD_CK_OPEN_RW_SESSION	0x0000000a
 
@@ -263,7 +263,7 @@ struct sks_mechanism_info {
  * SKS_CMD_CK_CLOSE_SESSION - Close an opened session
  *
  * [in]		memref[0] = 32bit session handle
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This commands relates to the PKCS#11 API function C_CloseSession().
  */
@@ -273,7 +273,7 @@ struct sks_mechanism_info {
  * SKS_CMD_CK_SESSION_INFO - Get Cryptoki information on a session
  *
  * [in]		memref[0] = 32bit session handle
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]        memref[2] = (struct sks_ck_session_info)info
  *
  * This commands relates to the PKCS#11 API function C_GetSessionInfo().
@@ -291,7 +291,7 @@ struct sks_session_info {
  * SKS_CMD_CK_CLOSE_ALL_SESSIONS - Close all client sessions on slot/token
  *
  * [in]		memref[0] = 32bit slot
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This commands relates to the PKCS#11 API function C_CloseAllSessions().
  */
@@ -304,7 +304,7 @@ struct sks_session_info {
  *			32bit session handle,
  *			(struct sks_object_head)attribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = 32bit object handle
  *
  * This commands relates to the PKCS#11 API function C_CreateObject().
@@ -339,7 +339,7 @@ struct sks_object_head {
  * structure followed by the attribute value, its byte size being defined
  * in the attribute header.
  *
- * @id - the 32bit identificator of the attribute, see SKS_CKA_<x>
+ * @id - the 32bit identifier of the attribute, see SKS_CKA_<x>
  * @size - the 32bit value attribute byte size
  * @data - then starts the attribute value
  */
@@ -356,21 +356,21 @@ struct sks_attribute_head {
  *			32bit session handle,
  *			32bit object handle
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This commands relates to the PKCS#11 API function C_DestroyObject().
  */
 #define SKS_CMD_DESTROY_OBJECT		0x0000000f
 
 /*
- * SKS_CMD_ENCRYPT_INIT - Initialize enryption processing
+ * SKS_CMD_ENCRYPT_INIT - Initialize encryption processing
  * SKS_CMD_DECRYPT_INIT - Initialize decryption processing
  *
  * [in]		memref[0] = [
  *			32bit session handle,
  *			(struct sks_attribute_head)mechanism + mecha parameters
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * These commands relate to the PKCS#11 API functions C_EncryptInit() and
  * C_DecryptInit.
@@ -384,7 +384,7 @@ struct sks_attribute_head {
  *
  * [in]		memref[0] = 32bit session handle
  * [in]		memref[1] = input data to be processed
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = output processed data
  *
  * These commands relate to the PKCS#11 API functions C_EncryptUpdate() and
@@ -398,7 +398,7 @@ struct sks_attribute_head {
  * SKS_CMD_DECRYPT_FINAL - Finalize decryption processing
  *
  * [in]		memref[0] = 32bit session handle
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = output processed data
  *
  * These commands relate to the PKCS#11 API functions C_EncryptFinal() and
@@ -415,7 +415,7 @@ struct sks_attribute_head {
  *			(struct sks_attribute_head)mechanism + mecha parameters,
  *			(struct sks_object_head)attribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = 32bit key handle
  *
  * This command relates to the PKCS#11 API functions C_GenerateKey().
@@ -431,7 +431,7 @@ struct sks_attribute_head {
  *			32bit key handle,
  *			(struct sks_attribute_head)mechanism + mecha parameters,
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * These commands relate to the PKCS#11 API functions C_SignInit() and
  * C_VerifyInit.
@@ -445,7 +445,7 @@ struct sks_attribute_head {
  *
  * [in]		memref[0] = 32bit session handle
  * [in]		memref[1] = input data to be processed
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * These commands relate to the PKCS#11 API functions C_SignUpdate() and
  * C_VerifyUpdate.
@@ -458,7 +458,7 @@ struct sks_attribute_head {
  * SKS_CMD_VERIFY_FINAL - Finalize a signature verification processing
  *
  * [in]		memref[0] = 32bit session handle
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = output processed data
  *
  * These commands relate to the PKCS#11 API functions C_SignFinal() and
@@ -474,7 +474,7 @@ struct sks_attribute_head {
  *			32bit session handle,
  *			(struct sks_object_head)attribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This command relates to the PKCS#11 API function C_FindOjectsInit().
  */
@@ -484,7 +484,7 @@ struct sks_attribute_head {
  * SKS_CMD_FIND_OBJECTS - Get handles of matching objects
  *
  * [in]		memref[0] = 32bit session handle
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = 32bit array object_handle_array[N]
  *
  * This command relates to the PKCS#11 API function C_FindOjects().
@@ -497,7 +497,7 @@ struct sks_attribute_head {
  * SKS_CMD_FIND_OBJECTS_FINAL - Finalize current objects search
  *
  * [in]		memref[0] = 32bit session handle
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * This command relates to the PKCS#11 API function C_FindOjectsFinal().
  */
@@ -510,7 +510,7 @@ struct sks_attribute_head {
  *			32bit session handle,
  *			32bit key handle
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = 32bit object_byte_size
  */
 #define SKS_CMD_GET_OBJECT_SIZE		0x00000020
@@ -523,7 +523,7 @@ struct sks_attribute_head {
  *			32bit object handle,
  *			(struct sks_object_head)attribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = (struct sks_object_head)attribs + attributes data
  */
 #define SKS_CMD_GET_ATTRIBUTE_VALUE	0x00000021
@@ -536,7 +536,7 @@ struct sks_attribute_head {
  *			32bit object handle,
  *			(struct sks_object_head)attribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = (struct sks_object_head)attribs + attributes data
  */
 #define SKS_CMD_SET_ATTRIBUTE_VALUE	0x00000022
@@ -550,7 +550,7 @@ struct sks_attribute_head {
  *			32bit key handle,
  *			(struct sks_object_head)attribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = 32bit object handle
  */
 #define SKS_CMD_DERIVE_KEY		0x00000023
@@ -563,7 +563,7 @@ struct sks_attribute_head {
  *			32bit PIN byte size,
  *			byte arrays: PIN data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  */
 #define SKS_CMD_INIT_PIN		0x00000024
 
@@ -577,7 +577,7 @@ struct sks_attribute_head {
  *			32bit new PIN byte size,
  *			byte arrays: new PIN data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  */
 #define SKS_CMD_SET_PIN			0x00000025
 
@@ -590,7 +590,7 @@ struct sks_attribute_head {
  *			32bit PIN byte size,
  *			byte arrays: PIN data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  */
 #define SKS_CMD_LOGIN			0x00000026
 
@@ -609,7 +609,7 @@ struct sks_attribute_head {
  *			32bit PIN byte size,
  *			byte array: PIN data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  */
 #define SKS_CMD_LOGOUT			0x00000027
 
@@ -622,7 +622,7 @@ struct sks_attribute_head {
  *			(struct sks_object_head)pubkey_attribs + attributes data
  *			(struct sks_object_head)privkeyattribs + attributes data
  *		]
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = [
  *			32bit public key handle,
  *			32bit prive key handle
@@ -638,7 +638,7 @@ struct sks_attribute_head {
  *
  * [in]		memref[0] = 32bit session handle
  * [in]		memref[1] = input data to be processed
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  * [out]	memref[2] = output processed data
  *
  * These commands relate to the PKCS#11 API functions C_EncryptUpdate() and
@@ -653,7 +653,7 @@ struct sks_attribute_head {
  *
  * [in]		memref[0] = 32bit session handle
  * [in]		memref[1] = input data to be processed
- * [out]	memref[0] = 32bit fine grain retrun code
+ * [out]	memref[0] = 32bit fine grain return code
  *
  * These commands relate to the PKCS#11 API functions C_SignUpdate() and
  * C_VerifyUpdate.
@@ -722,7 +722,7 @@ struct sks_attribute_head {
 #define SKS_TRUE				1
 
 /*
- * Attribute identificators
+ * Attribute identifiers
  * Valid values for struct sks_attribute_head::id
  *
  * SKS_ATTR_<x> corresponds to cryptoki CKA_<x>.
@@ -751,7 +751,7 @@ struct sks_attribute_head {
 #define SKS_CKA_DESTROYABLE			0x00000013
 #define SKS_CKA_ALWAYS_AUTHENTICATE		0x00000014
 #define SKS_CKA_WRAP_WITH_TRUSTED		0x00000015
-/* Last boolean properity ID (value is 63) is reserved */
+/* Last boolean property ID (value is 63) is reserved */
 #define SKS_BOOLPROPS_LAST			SKS_CKA_WRAP_WITH_TRUSTED
 #define SKS_BOOLPROPS_END			0x0000003F
 #define SKS_BOOLPROPH_FLAG			BIT(31)

--- a/ta/secure_key_services/src/attributes.c
+++ b/ta/secure_key_services/src/attributes.c
@@ -184,7 +184,7 @@ uint32_t remove_attribute_check(struct sks_attrs_head **head, uint32_t attribute
 
 		found++;
 		if (found > max_check) {
-			DMSG("Too many attribute occurences");
+			DMSG("Too many attribute occurrences");
 			return SKS_FAILED;
 		}
 
@@ -225,7 +225,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
 #ifdef SKS_SHEAD_WITH_BOOLPROPS
 	/* Can't return a pointer to a boolprop attribute */
 	if (head_contains_boolprops(head) && attribute_is_in_head(attribute)) {
-		EMSG("Can't get poitner to an attribute in the head");
+		EMSG("Can't get pointer to an attribute in the head");
 		TEE_Panic(0);
 	}
 #endif
@@ -405,7 +405,7 @@ bool attributes_match_reference(struct sks_attrs_head *candidate,
 
 #ifdef SKS_SHEAD_WITH_BOOLPROPS
 	/*
-	 * All boolprops attributes must ne explicitly defined
+	 * All boolprops attributes must be explicitly defined
 	 * as an attribute reference in the reference object.
 	 */
 	assert(!head_contains_boolprops(ref));
@@ -541,7 +541,7 @@ static uint32_t __trace_attributes(char *prefix, void *src, void *end)
 
 	/* Sanity */
 	if (cur != (char *)end) {
-		EMSG("Warning: unexpect alignment in object attibutes");
+		EMSG("Warning: unexpected alignment in object attributes");
 	}
 
 	TEE_Free(prefix2);

--- a/ta/secure_key_services/src/attributes.h
+++ b/ta/secure_key_services/src/attributes.h
@@ -65,11 +65,11 @@ uint32_t remove_attribute_check(struct sks_attrs_head **head, uint32_t attribute
  * the input attribute ID.
  *
  * If *count != 0, return the address and size of the attributes found, up to
- * the occurence number *conut. attr and attri_size and expected large
- * enougth. attr is the output array of the values found. attr_size is the
+ * the occurrence number *count. attr and attr_size and expected large
+ * enough. attr is the output array of the values found. attr_size is the
  * output array of the size of each values found.
  *
- * If attr_size != NULL, return in in *attr_size attribute value size .
+ * If attr_size != NULL, return in in *attr_size attribute value size.
  * If attr != NULL return in *attr the address in memory of the attribute value.
  */
 void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
@@ -77,7 +77,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
 
 /*
  * If attributes is not found return SKS_NOT_FOUND.
- * If attr_size != NULL, return in in *attr_size attribute value size .
+ * If attr_size != NULL, return in in *attr_size attribute value size.
  * If attr != NULL return in *attr the address in memory of the attribute value.
  *
  * Return a SKS_OK or SKS_NOT_FOUND on success, or a SKS return code.
@@ -85,7 +85,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
 uint32_t get_attribute_ptr(struct sks_attrs_head *head, uint32_t attribute,
 			   void **attr_ptr, size_t *attr_size);
 /*
- * If attributes is not found, rturn SKS_NOT_FOUND.
+ * If attribute is not found, return SKS_NOT_FOUND.
  * If attr_size != NULL, check *attr_size matches attributes size of return
  * SKS_SHORT_BUFFER with expected size in *attr_size.
  * If attr != NULL and attr_size is NULL or gives expected buffer size,

--- a/ta/secure_key_services/src/entry.c
+++ b/ta/secure_key_services/src/entry.c
@@ -14,7 +14,7 @@
 #include "processing.h"
 #include "sks_helpers.h"
 
-/* Client session context: currently only use the alloced address */
+/* Client session context: currently only use the allocated address */
 struct tee_session {
 	int foo;
 };
@@ -78,13 +78,13 @@ static uint32_t entry_ping(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 /*
  * Entry point for SKS TA commands
  *
- * ABI: param#0 is the control buffer with serialazed arguments.
+ * ABI: param#0 is the control buffer with serialized arguments.
  *	param#1 is an input/output data buffer
  *	param#2 is an input/output data buffer (also used to return handles)
  *	param#3 is not used
  *
  * Param#0 ctrl, if defined is an in/out buffer, is used to send back to
- * the client a Cryptoki status ID that superseeds the TEE result code which
+ * the client a Cryptoki status ID that supersedes the TEE result code which
  * will be force to TEE_SUCCESS. Note that some Cryptoki error status are
  * sent straight through TEE result code. See sks2tee_noerr().
  */
@@ -101,7 +101,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 	TEE_Result res = TEE_ERROR_GENERIC;
 	uint32_t rc = 0;
 
-	/* param#0: input buffer with request serialazed arguments */
+	/* param#0: input buffer with request serialized arguments */
 	switch (TEE_PARAM_TYPE_GET(ptypes, 0)) {
 	case TEE_PARAM_TYPE_NONE:
 		break;
@@ -359,7 +359,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *tee_session, uint32_t cmd,
 
 bad_types:
 	DMSG("Bad parameter types used at SKS TA entry:");
-	DMSG("- parameter #0: formated input request buffer or none");
+	DMSG("- parameter #0: formatted input request buffer or none");
 	DMSG("- parameter #1: processed input data buffer or none");
 	DMSG("- parameter #2: processed output data buffer or none");
 	DMSG("- parameter #3: none");

--- a/ta/secure_key_services/src/handle.h
+++ b/ta/secure_key_services/src/handle.h
@@ -38,7 +38,7 @@ void handle_db_destroy(struct handle_db *db);
 uint32_t handle_get(struct handle_db *db, void *ptr);
 
 /*
- * Deallocate a handle. Returns the assiciated pointer of the handle
+ * Deallocate a handle. Returns the associated pointer of the handle
  * the the handle was valid or NULL if it's invalid.
  */
 void *handle_put(struct handle_db *db, uint32_t handle);

--- a/ta/secure_key_services/src/object.c
+++ b/ta/secure_key_services/src/object.c
@@ -499,7 +499,7 @@ uint32_t entry_find_objects_init(uintptr_t tee_session, TEE_Param *ctrl,
 	 * candidates that match caller attributes. First scan all current
 	 * session objects (that are visible to the session). Then scan all
 	 * remaining persistent object for which no session object handle was
-	 * publised to the client.
+	 * published to the client.
 	 */
 
 	LIST_FOREACH(obj, &session->object_list, link) {
@@ -652,7 +652,7 @@ uint32_t entry_find_objects(uintptr_t tee_session, TEE_Param *ctrl,
 
 	}
 
-	/* Update output buffer accoriding the number of handles provided */
+	/* Update output buffer according the number of handles provided */
 	out->memref.size = count * sizeof(uint32_t);
 
 	IMSG("SKSs%" PRIu32 ": finding objects", session_handle);

--- a/ta/secure_key_services/src/pkcs11_attributes.c
+++ b/ta/secure_key_services/src/pkcs11_attributes.c
@@ -321,7 +321,7 @@ static uint8_t *pkcs11_object_default_boolprop(uint32_t attribute)
 /*
  * Object expects several boolean attributes to be set to a default value
  * or to a validate client configuration value. This function append the input
- * attrubute (id/size/value) in the serailzed object.
+ * attribute (id/size/value) in the serialized object.
  */
 static uint32_t pkcs11_import_object_boolprop(struct sks_attrs_head **out,
 					      struct sks_attrs_head *template,
@@ -405,10 +405,10 @@ static uint32_t set_optional_attributes(struct sks_attrs_head **out,
 }
 
 /*
- * Below are listed the mandated or optional epected attributes for
+ * Below are listed the mandated or optional expected attributes for
  * PKCS#11 storage objects.
  *
- * Note: boolprops (manadated boolean attributes) SKS_CKA_ALWAYS_SENSITIVE,
+ * Note: boolprops (mandated boolean attributes) SKS_CKA_ALWAYS_SENSITIVE,
  * and SKS_CKA_NEVER_EXTRACTABLE are set by the token, not provided
  * in the client template.
  */
@@ -487,14 +487,14 @@ static const uint32_t pkcs11_ec_public_key_mandated[] = {
 };
 static const uint32_t pkcs11_ec_public_key_optional[] = {
 	SKS_CKA_EC_POINT,
-	SKS_CKA_EC_POINT_X, SKS_CKA_EC_POINT_Y, // temporaary until DER support
+	SKS_CKA_EC_POINT_X, SKS_CKA_EC_POINT_Y, // temporarily until DER support
 };
 static const uint32_t pkcs11_ec_private_key_mandated[] = {
 	SKS_CKA_EC_PARAMS,
 };
 static const uint32_t pkcs11_ec_private_key_optional[] = {
 	SKS_CKA_VALUE,
-	SKS_CKA_EC_POINT_X, SKS_CKA_EC_POINT_Y, // temporaary until DER support
+	SKS_CKA_EC_POINT_X, SKS_CKA_EC_POINT_Y, // temporarily until DER support
 };
 
 static uint32_t create_pkcs11_storage_attributes(struct sks_attrs_head **out,
@@ -754,17 +754,17 @@ static uint32_t create_pkcs11_priv_key_attributes(struct sks_attrs_head **out,
  * object (optional) for an object generation function (generate, copy,
  * derive...).
  *
- * PKCS#11 directves on the supplied template:
- * - template has aninvalid attribute ID: return ATTRIBUTE_TYPE_INVALID
+ * PKCS#11 directives on the supplied template:
+ * - template has an invalid attribute ID: return ATTRIBUTE_TYPE_INVALID
  * - template has an invalid value for an attribute: return ATTRIBUTE_VALID_INVALID
- * - template has value for a read-only attribute: retrun ATTRIBUTE_READ_ONLY
+ * - template has value for a read-only attribute: return ATTRIBUTE_READ_ONLY
  * - template+default+parent => still miss an attribute: return TEMPLATE_INCONSISTENT
  *
  * INFO on SKS_CMD_COPY_OBJECT:
  * - parent SKS_CKA_COPYIABLE=false => return ACTION_PROHIBITED.
  * - template can specify SKS_CKA_TOKEN, SKS_CKA_PRIVATE, SKS_CKA_MODIFIABLE,
  *   SKS_CKA_DESTROYABLE.
- * - SENSITIVE can change from flase to true, not from true to false.
+ * - SENSITIVE can change from false to true, not from true to false.
  * - LOCAL is the parent LOCAL
  */
 uint32_t create_attributes_from_template(struct sks_attrs_head **out,
@@ -1030,11 +1030,11 @@ uint32_t check_created_attrs_against_processing(uint32_t proc_id,
 	uint8_t bbool = 0;
 
 	/*
-	 * Processings that do not create secrets are not expected to call
+	 * Processing that do not create secrets are not expected to call
 	 * this function which would panic.
 	 */
 	/*
-	 * FIXME: rellay need to check LOCAL here, it was safely set from
+	 * FIXME: really need to check LOCAL here, it was safely set from
 	 * create_attributes_from_template().
 	 */
 	switch (proc_id) {
@@ -1256,7 +1256,7 @@ uint32_t check_created_attrs(struct sks_attrs_head *key1,
 
 	/*
 	 * Check key size for symmetric keys and RSA keys
-	 * EC is bound to domains, no need to chekc here.
+	 * EC is bound to domains, no need to check here.
 	 */
 	switch (get_type(key1)) {
 	case SKS_CKK_EC:
@@ -1277,7 +1277,7 @@ uint32_t check_created_attrs(struct sks_attrs_head *key1,
 	return SKS_OK;
 }
 
-/* Check processing ID against attributre ALLOWED_PROCESSINGS if any */
+/* Check processing ID against attribute ALLOWED_PROCESSINGS if any */
 static bool parent_key_complies_allowed_processings(uint32_t proc_id,
 						    struct sks_attrs_head *head)
 {

--- a/ta/secure_key_services/src/pkcs11_attributes.h
+++ b/ta/secure_key_services/src/pkcs11_attributes.h
@@ -33,15 +33,15 @@
 
 /*
  * Utils to check compliance of attributes at various processing steps.
- * Any rocessing operation is exclusively one of the following.
+ * Any processing operation is exclusively one of the following.
  *
  * Case 1: Create a secret from some local random value (C_CreateKey & friends)
- * - client provides a attributs list template, pkcs11 complete with default
+ * - client provides a attributes list template, pkcs11 complete with default
  *   attribute values. Object is created if attributes are consistent and
  *   comply token/session stte.
  * - SKS sequence:
  *   - check/set token/session state
- *   - create a attribute list from client template and defualt values.
+ *   - create a attribute list from client template and default values.
  *   - check new secret attributes complies requested mechanism .
  *   - check new secret attributes complies token/session state.
  *   - Generate the value for the secret.
@@ -50,11 +50,11 @@
 
  *
  * Case 2: Create a secret from a client clear data (C_CreateObject)
- * - client provides a attributs list template, pkcs11 complete with default
- *   attribute values. Object is created if attributes are consitent and
+ * - client provides a attributes list template, pkcs11 complete with default
+ *   attribute values. Object is created if attributes are consistent and
  *   comply token/session state.
  *   - check/set token/session state
- *   - create a attribute list from client template and defualt values.
+ *   - create a attribute list from client template and default values.
  *   - check new secret attributes complies requested mechanism (raw-import).
  *   - check new secret attributes complies token/session state.
  *   - Set some runtime attributes in the new secret.

--- a/ta/secure_key_services/src/pkcs11_token.c
+++ b/ta/secure_key_services/src/pkcs11_token.c
@@ -532,7 +532,7 @@ uint32_t entry_ck_token_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 	TEE_MemMove(&info.hardwareVersion, &hwver, sizeof(hwver));
 	TEE_MemMove(&info.firmwareVersion, &fwver, sizeof(hwver));
 
-	// TODO: get time and convert from refence into YYYYMMDDhhmmss/UTC
+	// TODO: get time and convert from reference into YYYYMMDDhhmmss/UTC
 	TEE_MemFill(info.utcTime, 0, sizeof(info.utcTime));
 
 	/* Return to caller with data */
@@ -848,7 +848,7 @@ static void set_session_state(struct pkcs11_client *client,
 
 	/*
 	 * No need to check all client session, only the first session on
-	 * target token gives client loggin configuration.
+	 * target token gives client login configuration.
 	 */
 	TAILQ_FOREACH(sess, &client->session_list, link) {
 		assert(sess != session);
@@ -991,7 +991,7 @@ static uint32_t open_ck_session(uintptr_t tee_session, TEE_Param *ctrl,
 
 	client = tee_session2client(tee_session);
 	if (!client) {
-		EMSG("Unexpected invlaid TEE session handle");
+		EMSG("Unexpected invalid TEE session handle");
 		return SKS_FAILED;
 	}
 
@@ -1066,7 +1066,7 @@ static void close_ck_session(struct pkcs11_session *session)
 	handle_put(&session->client->session_handle_db, session->handle);
 	handle_db_destroy(&session->object_handle_db);
 
-	// If no more session, next opened one will simply be Public loggin
+	// If no more session, next opened one will simply be Public login
 
 	session->token->session_count--;
 	if (pkcs11_session_is_read_write(session))

--- a/ta/secure_key_services/src/pkcs11_token.h
+++ b/ta/secure_key_services/src/pkcs11_token.h
@@ -60,10 +60,10 @@ TAILQ_HEAD(session_list, pkcs11_session);
  * @label - pkcs11 formatted token label, set by client
  * @flags - pkcs11 token flags
  * @so_pin_count - counter on security officer login failure
- * @so_pin_size - byte size of the provisionned SO PIN
+ * @so_pin_size - byte size of the provisioned SO PIN
  * @so_pin - stores the SO PIN
  * @user_pin_count - counter on user login failure
- * @user_pin_size - byte size of the provisionned user PIN
+ * @user_pin_size - byte size of the provisioned user PIN
  * @user_pin - stores the user PIN
  */
 struct token_persistent_main {
@@ -118,8 +118,8 @@ struct ck_token {
 };
 
 /*
- * A session can enter a processing state (encrypt, decrypt, disgest, ...
- * only from the inited state. A sesion must return the the inited
+ * A session can enter a processing state (encrypt, decrypt, digest, ...
+ * only from the initialized state. A session must return the initialized
  * state (from a processing finalization request) before entering another
  * processing state.
  */
@@ -161,7 +161,7 @@ struct active_processing {
 };
 
 /*
- * Pkcs11 objects serach context
+ * Pkcs11 objects search context
  *
  * @attributes - matching attributes list searched (null if no search)
  * @count - number of matching handle found
@@ -194,9 +194,9 @@ struct pkcs11_client {
 /*
  * Structure tracking the PKCS#11 sessions
  *
- * @link - list of the session belowing to a client
+ * @link - list of the session belonging to a client
  * @tee_session - TEE session handle used by PKCS11 session client
- * @client - client the session belongs to (FIXME: redondant with tee_session)
+ * @client - client the session belongs to (FIXME: redundant with tee_session)
  * @token - token this session belongs to
  * @handle - identifier of the session published to the client
  * @object_list - entry of the session objects list

--- a/ta/secure_key_services/src/processing.c
+++ b/ta/secure_key_services/src/processing.c
@@ -172,7 +172,7 @@ uint32_t entry_import_object(uintptr_t tee_session,
 
 	/*
 	 * Prepare a clean initial state for the requested object attributes.
-	 * Free temorary template once done.
+	 * Free temporary template once done.
 	 */
 	rv = create_attributes_from_template(&head, template, template_size,
 					     NULL, SKS_FUNCTION_IMPORT);
@@ -356,7 +356,7 @@ uint32_t entry_generate_secret(uintptr_t tee_session,
 
 	/*
 	 * Prepare a clean initial state for the requested object attributes.
-	 * Free temorary template once done.
+	 * Free temporary template once done.
 	 */
 	rv = create_attributes_from_template(&head, template, template_size,
 					     NULL, SKS_FUNCTION_GENERATE);
@@ -380,7 +380,7 @@ uint32_t entry_generate_secret(uintptr_t tee_session,
 
 	/*
 	 * Execute target processing and add value as attribute SKS_CKA_VALUE.
-	 * Symm key generation: depens on target processing to be used.
+	 * Symm key generation: depends on target processing to be used.
 	 */
 	switch (proc_params->id) {
 	case SKS_CKM_GENERIC_SECRET_KEY_GEN:
@@ -643,7 +643,7 @@ bail:
  * @ctrl = [session-handle]
  * @in = input data or none
  * @out = output data or none
- * @function - encrypt, decrypt, sign, verify, disgest, ...
+ * @function - encrypt, decrypt, sign, verify, digest, ...
  *
  * The generic part come that all the commands uses the same
  * input/output invocation parameters format (ctrl/in/out).
@@ -734,7 +734,7 @@ bail:
  * @ctrl = [session-handle]
  * @in = input data or none
  * @out = output data or none
- * @function - encrypt, decrypt, sign, verify, disgest, ...
+ * @function - encrypt, decrypt, sign, verify, digest, ...
  * @step - update, oneshot, final
  *
  * The generic part come that all the commands uses the same
@@ -767,7 +767,7 @@ uint32_t entry_processing_step(uintptr_t tee_session, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	// TODO: check user authen and object activiation dates
+	// TODO: check user authen and object activation dates
 	mecha_type = session->processing->mecha_type;
 	rv = check_mechanism_against_processing(session, mecha_type,
 						function, step);
@@ -795,7 +795,7 @@ bail:
 			release_active_processing(session);
 		break;
 	default:
-		/* ONESHOT and FINAL terminates procceesing on success */
+		/* ONESHOT and FINAL terminates processing on success */
 		if (rv != SKS_SHORT_BUFFER)
 			release_active_processing(session);
 		break;
@@ -810,7 +810,7 @@ bail:
  * @ctrl = [session-handle]
  * @in = input data or none
  * @out = output data or none
- * @function - encrypt, decrypt, sign, verify, disgest, ...
+ * @function - encrypt, decrypt, sign, verify, digest, ...
  * @step - update, oneshot, final
  *
  * The generic part come that all the commands uses the same
@@ -845,7 +845,7 @@ uint32_t entry_verify_oneshot(uintptr_t tee_session, TEE_Param *ctrl,
 	if (rv)
 		return rv;
 
-	// TODO: check user authen and object activiation dates
+	// TODO: check user authen and object activation dates
 	mecha_type = session->processing->mecha_type;
 	rv = check_mechanism_against_processing(session, mecha_type,
 						function, step);

--- a/ta/secure_key_services/src/processing.h
+++ b/ta/secure_key_services/src/processing.h
@@ -14,7 +14,7 @@ struct sks_object;
 struct active_processing;
 
 /*
- * Entry points frpom SKS TA invocation commands
+ * Entry points from SKS TA invocation commands
  */
 
 uint32_t entry_import_object(uintptr_t teesess, TEE_Param *ctrl,

--- a/ta/secure_key_services/src/processing_aes.c
+++ b/ta/secure_key_services/src/processing_aes.c
@@ -152,7 +152,7 @@ uint32_t tee_ae_decrypt_update(struct active_processing *processing,
 		return SKS_OK;
 	}
 
-	/* Size of data that are not potential tag in pendings and input data */
+	/* Size of data that are not potential tag in pending and input data */
 	data_len = in_size + ctx->pending_size - ctx->tag_byte_len;
 
 	if (ctx->pending_size &&
@@ -196,7 +196,7 @@ uint32_t tee_ae_decrypt_update(struct active_processing *processing,
 			}
 		}
 
-		/* Save pontential tag bytes for later */
+		/* Save potential tag bytes for later */
 		TEE_MemMove(ctx->pending_tag, ctx->pending_tag + len,
 			    ctx->pending_size - len);
 
@@ -328,7 +328,7 @@ uint32_t tee_ae_decrypt_final(struct active_processing *processing,
 		return reveale_ae_data(ctx, out, out_size);
 
 	if (ctx->pending_size != ctx->tag_byte_len) {
-		DMSG("Not enougth samples: %u/%u",
+		DMSG("Not enough samples: %u/%u",
 			ctx->pending_size, ctx->tag_byte_len);
 		return SKS_FAILED;	// FIXME: CKR_ENCRYPTED_DATA_LEN_RANGE
 	}

--- a/ta/secure_key_services/src/processing_asymm.c
+++ b/ta/secure_key_services/src/processing_asymm.c
@@ -363,7 +363,7 @@ uint32_t init_asymm_operation(struct pkcs11_session *session,
  * @function -
  * @step - step ID in the processing (oneshot, update,final)
  * @in - input data reference #1
- * @io2 - nput/output data reference #2 (direction depends on function)
+ * @io2 - input/output data reference #2 (direction depends on function)
  */
 uint32_t step_asymm_operation(struct pkcs11_session *session,
 			      enum processing_func function,

--- a/ta/secure_key_services/src/processing_ec.c
+++ b/ta/secure_key_services/src/processing_ec.c
@@ -918,7 +918,7 @@ size_t ec_params2tee_keysize(void *ec_params, size_t size)
 }
 
 /*
- * This function intentionnally panics if the curve is not found.
+ * This function intentionally panics if the curve is not found.
  * Use ec_params2tee_keysize() to check the curve is supported by
  * the internal core API.
  */

--- a/ta/secure_key_services/src/sanitize_object.c
+++ b/ta/secure_key_services/src/sanitize_object.c
@@ -159,7 +159,7 @@ static uint32_t sanitize_boolprop(struct sks_attrs_head **dst,
 	uint32_t *boolprop_ptr = NULL;
 	uint32_t *sanity_ptr = NULL;
 
-	/* Get the booloean property shift position and value */
+	/* Get the boolean property shift position and value */
 	shift = sks_attr2boolprop_shift(cli_ref->id);
 	if (shift < 0)
 		return SKS_NOT_FOUND;
@@ -335,7 +335,7 @@ uint32_t sanitize_client_object(struct sks_attrs_head **dst,
 
 	/* sanity */
 	if (cur != end) {
-		EMSG("Unexpected alignment inssue");
+		EMSG("Unexpected alignment issue");
 		rc = SKS_FAILED;
 		goto bail;
 	}

--- a/ta/secure_key_services/src/sanitize_object.h
+++ b/ta/secure_key_services/src/sanitize_object.h
@@ -21,12 +21,12 @@ bool sanitize_consistent_class_and_type(struct sks_attrs_head *attrs);
  * sanitize_client_object - Setup a serializer from a serialized object
  *
  * @dst - output structure tracking the generated serial object
- * @head - pointer to the formated serialized object (its head)
+ * @head - pointer to the formatted serialized object (its head)
  * @size - byte size of the serialized binary blob
  *
  * This function copies an attribute list from a client API attribute head
  * into a SKS internal attribute structure. It generates a serialized attribute
- * list with a consistent format and identifed attribute IDs.
+ * list with a consistent format and identified attribute IDs.
  *
  * ref points to a blob starting with a sks head.
  * ref may pointer to an unaligned address.

--- a/ta/secure_key_services/src/serializer.c
+++ b/ta/secure_key_services/src/serializer.c
@@ -169,7 +169,7 @@ uint32_t serialargs_alloc_get_attributes(struct serialargs *args __unused,
  * serialize - serialize input data in buffer
  *
  * Serialize data in provided buffer.
- * Insure 64byte alignement of appended data in the buffer.
+ * Insure 64byte alignment of appended data in the buffer.
  */
 uint32_t serialize(char **bstart, size_t *blen, void *data, size_t len)
 {

--- a/ta/secure_key_services/src/sks_helpers.h
+++ b/ta/secure_key_services/src/sks_helpers.h
@@ -44,7 +44,7 @@ bool sks2tee_load_attr(TEE_Attribute *tee_ref, uint32_t tee_id,
 			struct sks_object *obj, uint32_t sks_id);
 
 /*
- * Convert SKS retrun code into a GPD TEE result ID when matching.
+ * Convert SKS return code into a GPD TEE result ID when matching.
  * If not, return a TEE success (_noerr) or generic error (_error).
  */
 TEE_Result sks2tee_noerr(uint32_t rv);


### PR DESCRIPTION
Typos I found when reading the codebase, no functional changes, just
cosmetics.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>