### PR TITLE
sks ta: use uint32_t for attr_size

### DIFF
--- a/ta/secure_key_services/src/attributes.c
+++ b/ta/secure_key_services/src/attributes.c
@@ -212,7 +212,7 @@ uint32_t remove_attribute_check(struct sks_attrs_head **head, uint32_t attribute
 }
 
 void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
-			void **attr, size_t *attr_size, size_t *count)
+			void **attr, uint32_t *attr_size, size_t *count)
 {
 	char *cur = (char *)head + sizeof(struct sks_attrs_head);
 	char *end = cur + head->attrs_size;
@@ -220,7 +220,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
 	size_t max_found = *count;
 	size_t found = 0;
 	void **attr_ptr = attr;
-	size_t *attr_size_ptr = attr_size;
+	uint32_t *attr_size_ptr = attr_size;
 
 #ifdef SKS_SHEAD_WITH_BOOLPROPS
 	/* Can't return a pointer to a boolprop attribute */
@@ -265,7 +265,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
 }
 
 uint32_t get_attribute_ptr(struct sks_attrs_head *head, uint32_t attribute,
-			   void **attr_ptr, size_t *attr_size)
+			   void **attr_ptr, uint32_t *attr_size)
 {
 	size_t count = 1;
 
@@ -305,11 +305,11 @@ uint32_t get_attribute_ptr(struct sks_attrs_head *head, uint32_t attribute,
 }
 
 uint32_t get_attribute(struct sks_attrs_head *head, uint32_t attribute,
-			void *attr, size_t *attr_size)
+			void *attr, uint32_t *attr_size)
 {
 	uint32_t rc = 0;
 	void *attr_ptr = NULL;
-	size_t size = 0;
+	uint32_t size = 0;
 	uint8_t __maybe_unused bbool = 0;
 	int __maybe_unused shift = 0;
 
@@ -366,7 +366,7 @@ bool get_bool(struct sks_attrs_head *head, uint32_t attribute)
 {
 	uint32_t __maybe_unused rc = 0;
 	uint8_t bbool = 0;
-	size_t size = sizeof(bbool);
+	uint32_t size = sizeof(bbool);
 	int __maybe_unused shift = 0;
 
 #ifdef SKS_SHEAD_WITH_BOOLPROPS
@@ -414,7 +414,7 @@ bool attributes_match_reference(struct sks_attrs_head *candidate,
 	for (count = 0; count < ref->attrs_count; count++) {
 		struct sks_ref sks_ref;
 		void *found = NULL;
-		size_t size = 0;
+		uint32_t size = 0;
 		int shift = 0;
 
 		TEE_MemMove(&sks_ref, ref_attr, sizeof(sks_ref));

--- a/ta/secure_key_services/src/attributes.h
+++ b/ta/secure_key_services/src/attributes.h
@@ -73,7 +73,7 @@ uint32_t remove_attribute_check(struct sks_attrs_head **head, uint32_t attribute
  * If attr != NULL return in *attr the address in memory of the attribute value.
  */
 void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
-			void **attr, size_t *attr_size, size_t *count);
+			void **attr, uint32_t *attr_size, size_t *count);
 
 /*
  * If attributes is not found return SKS_NOT_FOUND.
@@ -83,7 +83,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
  * Return a SKS_OK or SKS_NOT_FOUND on success, or a SKS return code.
  */
 uint32_t get_attribute_ptr(struct sks_attrs_head *head, uint32_t attribute,
-			   void **attr_ptr, size_t *attr_size);
+			   void **attr_ptr, uint32_t *attr_size);
 /*
  * If attributes is not found, rturn SKS_NOT_FOUND.
  * If attr_size != NULL, check *attr_size matches attributes size of return
@@ -94,12 +94,12 @@ uint32_t get_attribute_ptr(struct sks_attrs_head *head, uint32_t attribute,
  * Return a SKS_OK or SKS_NOT_FOUND on success, or a SKS return code.
  */
 uint32_t get_attribute(struct sks_attrs_head *head, uint32_t attribute,
-			void *attr, size_t *attr_size);
+			void *attr, uint32_t *attr_size);
 
 static inline uint32_t get_u32_attribute(struct sks_attrs_head *head,
 					 uint32_t attribute, uint32_t *attr)
 {
-	size_t size = sizeof(uint32_t);
+	uint32_t size = sizeof(uint32_t);
 	uint32_t rv = get_attribute(head, attribute, attr, &size);
 
 	if (size != sizeof(uint32_t))
@@ -139,7 +139,7 @@ static inline uint32_t get_type(struct sks_attrs_head *head)
 static inline uint32_t get_class(struct sks_attrs_head *head)
 {
 	uint32_t class;
-	size_t size = sizeof(class);
+	uint32_t size = sizeof(class);
 
 	if (get_attribute(head, SKS_CKA_CLASS, &class, &size))
 		return SKS_UNDEFINED_ID;
@@ -149,7 +149,7 @@ static inline uint32_t get_class(struct sks_attrs_head *head)
 static inline uint32_t get_type(struct sks_attrs_head *head)
 {
 	uint32_t type;
-	size_t size = sizeof(type);
+	uint32_t size = sizeof(type);
 
 	if (get_attribute(head, SKS_CKA_KEY_TYPE, &type, &size))
 		return SKS_UNDEFINED_ID;

--- a/ta/secure_key_services/src/pkcs11_attributes.c
+++ b/ta/secure_key_services/src/pkcs11_attributes.c
@@ -329,7 +329,7 @@ static uint32_t pkcs11_import_object_boolprop(struct sks_attrs_head **out,
 {
 	uint32_t rv = 0;
 	uint8_t bbool = 0;
-	size_t size = sizeof(uint8_t);
+	uint32_t size = sizeof(uint8_t);
 	void *attr = NULL;
 
 	rv = get_attribute(template, attribute, &bbool, &size);
@@ -366,7 +366,7 @@ static uint32_t __unused set_mandatory_attributes(struct sks_attrs_head **out,
 	size_t n = 0;
 
 	for (n = 0; n < bp_count; n++) {
-		size_t size = 0;
+		uint32_t size = 0;
 		void *value = NULL;
 
 		if (get_attribute_ptr(temp, bp[n], &value, &size)) {
@@ -390,7 +390,7 @@ static uint32_t set_optional_attributes(struct sks_attrs_head **out,
 	size_t n = 0;
 
 	for (n = 0; n < bp_count; n++) {
-		size_t size = 0;
+		uint32_t size = 0;
 		void *value = NULL;
 
 		if (get_attribute_ptr(temp, bp[n], &value, &size))
@@ -1282,7 +1282,7 @@ static bool parent_key_complies_allowed_processings(uint32_t proc_id,
 						    struct sks_attrs_head *head)
 {
 	char *attr = NULL;
-	size_t size = 0;
+	uint32_t size = 0;
 	uint32_t proc = 0;
 	size_t count = 0;
 
@@ -1504,9 +1504,9 @@ uint32_t add_missing_attribute_id(struct sks_attrs_head **attrs1,
 {
 	uint32_t rv = 0;
 	void *id1 = NULL;
-	size_t id1_size = 0;
+	uint32_t id1_size = 0;
 	void *id2 = NULL;
-	size_t id2_size = 0;
+	uint32_t id2_size = 0;
 
 	rv = get_attribute_ptr(*attrs1, SKS_CKA_ID, &id1, &id1_size);
 	if (rv) {
@@ -1556,7 +1556,7 @@ bool attribute_is_exportable(struct sks_attribute_head *req_attr,
 			     struct sks_object *obj)
 {
 	uint8_t boolval = 0;
-	size_t boolsize = 0;
+	uint32_t boolsize = 0;
 	uint32_t rv = 0;
 
 	switch (req_attr->id) {

--- a/ta/secure_key_services/src/processing.c
+++ b/ta/secure_key_services/src/processing.c
@@ -231,7 +231,7 @@ bail:
 size_t get_object_key_bit_size(struct sks_object *obj)
 {
 	void *a_ptr = NULL;
-	size_t a_size = 0;
+	uint32_t a_size = 0;
 	struct sks_attrs_head *attrs = obj->attributes;
 
 	switch (get_type(attrs)) {
@@ -271,7 +271,7 @@ static uint32_t generate_random_key_value(struct sks_attrs_head **head)
 {
 	uint32_t rv = 0;
 	void *data;
-	size_t data_size;
+	uint32_t data_size;
 	uint32_t value_len;
 	void *value;
 
@@ -434,7 +434,7 @@ uint32_t alloc_get_tee_attribute_data(TEE_ObjectHandle tee_obj,
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	void *ptr = NULL;
-	size_t sz = 0;
+	uint32_t sz = 0;
 
 	res = TEE_GetObjectBufferAttribute(tee_obj, attribute, NULL, &sz);
 	if (res != TEE_ERROR_SHORT_BUFFER)

--- a/ta/secure_key_services/src/processing_ec.c
+++ b/ta/secure_key_services/src/processing_ec.c
@@ -1172,7 +1172,7 @@ uint32_t generate_ec_keys(struct sks_attribute_head *proc_params,
 {
 	uint32_t rv = 0;
 	void *a_ptr = NULL;
-	size_t a_size = 0;
+	uint32_t a_size = 0;
 	uint32_t tee_size = 0;
 	uint32_t tee_curve = 0;
 	TEE_ObjectHandle tee_obj = TEE_HANDLE_NULL;

--- a/ta/secure_key_services/src/processing_rsa.c
+++ b/ta/secure_key_services/src/processing_rsa.c
@@ -437,7 +437,7 @@ uint32_t generate_rsa_keys(struct sks_attribute_head *proc_params,
 {
 	uint32_t rv;
 	void *a_ptr;
-	size_t a_size;
+	uint32_t a_size;
 	TEE_ObjectHandle tee_obj;
 	TEE_Result res;
 	uint32_t tee_size;

--- a/ta/secure_key_services/src/sks_helpers.c
+++ b/ta/secure_key_services/src/sks_helpers.c
@@ -597,7 +597,7 @@ bool sks2tee_load_attr(TEE_Attribute *tee_ref, uint32_t tee_id,
 			struct sks_object *obj, uint32_t sks_id)
 {
 	void *a_ptr = NULL;
-	size_t a_size = 0;
+	uint32_t a_size = 0;
 	uint32_t data32 = 0;
 
 	switch (tee_id) {


### PR DESCRIPTION
sks attr_size is expected to be uint32_t, so sync the variable type with
the related get attribute calls to avoid mismatch with size_t.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>