### PR TITLE
sks ta: fix initialization of local variables

### DIFF
--- a/ta/secure_key_services/src/attributes.c
+++ b/ta/secure_key_services/src/attributes.c
@@ -232,7 +232,7 @@ void get_attribute_ptrs(struct sks_attrs_head *head, uint32_t attribute,
 
 	for (; cur < end; cur += next_off) {
 		/* Structure aligned copy of the sks_ref in the object */
-		struct sks_ref sks_ref;
+		struct sks_ref sks_ref = { };
 
 		TEE_MemMove(&sks_ref, cur, sizeof(sks_ref));
 		next_off = sizeof(sks_ref) + sks_ref.size;
@@ -412,7 +412,7 @@ bool attributes_match_reference(struct sks_attrs_head *candidate,
 #endif
 
 	for (count = 0; count < ref->attrs_count; count++) {
-		struct sks_ref sks_ref;
+		struct sks_ref sks_ref = { };
 		void *found = NULL;
 		uint32_t size = 0;
 		int shift = 0;
@@ -472,7 +472,7 @@ static uint32_t __trace_attributes(char *prefix, void *src, void *end)
 	*(prefix2 + prefix_len + 4) = '\0';
 
 	for (; cur < (char *)end; cur += next_off) {
-		struct sks_ref sks_ref;
+		struct sks_ref sks_ref = { };
 		uint8_t data[4] = { 0 };
 
 		TEE_MemMove(&sks_ref, cur, sizeof(sks_ref));
@@ -565,7 +565,7 @@ static void trace_boolprops(const char *prefix, struct sks_attrs_head *head)
 
 uint32_t trace_attributes(const char *prefix, void *ref)
 {
-	struct sks_attrs_head head;
+	struct sks_attrs_head head = { };
 	char *pre = NULL;
 	uint32_t rc = 0;
 	size_t __maybe_unused n = 0;

--- a/ta/secure_key_services/src/object.c
+++ b/ta/secure_key_services/src/object.c
@@ -72,7 +72,7 @@ static void cleanup_volatile_obj_ref(struct sks_object *obj)
 static void cleanup_persistent_object(struct sks_object *obj,
 				      struct ck_token *token)
 {
-	TEE_Result res;
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (!obj)
 		return;
@@ -268,14 +268,12 @@ bail:
 uint32_t entry_destroy_object(uintptr_t tee_session, TEE_Param *ctrl,
 				TEE_Param *in, TEE_Param *out)
 {
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	uint32_t object_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_object *object = NULL;
 	uint32_t rv = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -316,11 +314,9 @@ static uint32_t token_obj_matches_ref(struct sks_attrs_head *req_attrs,
 	uint32_t rv = 0;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_ObjectHandle hdl = obj->attribs_hdl;
-	TEE_ObjectInfo info;
+	TEE_ObjectInfo info = { };
 	struct sks_attrs_head *attr = NULL;
 	uint32_t read_bytes = 0;
-
-	TEE_MemFill(&info, 0, sizeof(info));
 
 	if (obj->attributes) {
 		if (!attributes_match_reference(obj->attributes, req_attrs))
@@ -421,15 +417,13 @@ uint32_t entry_find_objects_init(uintptr_t tee_session, TEE_Param *ctrl,
 				 TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_object_head *template = NULL;
 	struct sks_attrs_head *req_attrs = NULL;
 	struct sks_object *obj = NULL;
 	struct pkcs11_find_objects *find_ctx = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -597,7 +591,7 @@ uint32_t entry_find_objects(uintptr_t tee_session, TEE_Param *ctrl,
 			    TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct pkcs11_find_objects *ctx = NULL;
@@ -605,8 +599,6 @@ uint32_t entry_find_objects(uintptr_t tee_session, TEE_Param *ctrl,
 	size_t out_count = 0;
 	size_t count = 0;
 	size_t idx = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -673,11 +665,9 @@ uint32_t entry_find_objects_final(uintptr_t tee_session, TEE_Param *ctrl,
 				  TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 9;
 	struct pkcs11_session *session = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -707,7 +697,7 @@ uint32_t entry_get_attribute_value(uintptr_t tee_session, TEE_Param *ctrl,
 				   TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_object_head *template = NULL;
@@ -719,8 +709,6 @@ uint32_t entry_get_attribute_value(uintptr_t tee_session, TEE_Param *ctrl,
 	bool attr_sensitive = 0;
 	bool attr_type_invalid = 0;
 	bool buffer_too_small = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;

--- a/ta/secure_key_services/src/persistent_token.c
+++ b/ta/secure_key_services/src/persistent_token.c
@@ -83,11 +83,9 @@ static void init_pin_keys(struct ck_token *token, unsigned int uid)
 	}
 
 	if (res == TEE_ERROR_ITEM_NOT_FOUND) {
-		TEE_Attribute attr;
+		TEE_Attribute attr = { };
 		TEE_ObjectHandle hdl = TEE_HANDLE_NULL;
 		uint8_t pin_key[16] = { 0 };
-
-		TEE_MemFill(&attr, 0, sizeof(attr));
 
 		TEE_GenerateRandom(pin_key, sizeof(pin_key));
 		TEE_InitRefAttribute(&attr, TEE_ATTR_SECRET_VALUE,
@@ -168,7 +166,7 @@ uint32_t unregister_persistent_object(struct ck_token *token, TEE_UUID *uuid)
 {
 	int index = 0;
 	int count = 0;
-	struct token_persistent_objs *ptr;
+	struct token_persistent_objs *ptr = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (!uuid)

--- a/ta/secure_key_services/src/pkcs11_token.c
+++ b/ta/secure_key_services/src/pkcs11_token.c
@@ -48,7 +48,7 @@ unsigned int get_token_id(struct ck_token *token)
 /* Client */
 struct pkcs11_client *tee_session2client(uintptr_t tee_session)
 {
-	struct pkcs11_client *client;
+	struct pkcs11_client *client = NULL;
 
 	TAILQ_FOREACH(client, &pkcs11_client_list, link) {
 		if (client == (void *)tee_session)
@@ -178,10 +178,8 @@ int set_processing_state(struct pkcs11_session *session,
 			 enum processing_func function,
 			 struct sks_object *obj1, struct sks_object *obj2)
 {
-	enum pkcs11_proc_state state;
+	enum pkcs11_proc_state state = PKCS11_SESSION_READY;
 	struct active_processing *proc = NULL;
-
-	TEE_MemFill(&state, 0, sizeof(state));
 
 	if (session->processing)
 		return SKS_CKR_OPERATION_ACTIVE;
@@ -260,17 +258,15 @@ uint32_t entry_ck_token_initialize(TEE_Param *ctrl,
 				   TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	uint32_t pin_size = 0;
 	void *pin = NULL;
 	char label[SKS_TOKEN_LABEL_SIZE + 1] = { 0 };
-	struct ck_token *token;
+	struct ck_token *token = NULL;
 	uint8_t *cpin = NULL;
 	int pin_rc = 0;
-	struct pkcs11_client *client;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
+	struct pkcs11_client *client = NULL;
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -418,17 +414,14 @@ uint32_t entry_ck_slot_list(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 uint32_t entry_ck_slot_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	struct ck_token *token = NULL;
 	const char desc[] = SKS_CRYPTOKI_SLOT_DESCRIPTION;
 	const char manuf[] = SKS_CRYPTOKI_SLOT_MANUFACTURER;
 	const char hwver[2] = SKS_CRYPTOKI_SLOT_HW_VERSION;
 	const char fwver[2] = SKS_CRYPTOKI_SLOT_FW_VERSION;
-	struct sks_slot_info info;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
-	TEE_MemFill(&info, 0, sizeof(info));
+	struct sks_slot_info info = { };
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -451,8 +444,6 @@ uint32_t entry_ck_slot_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 	if (!token)
 		return SKS_CKR_SLOT_ID_INVALID;
 
-	TEE_MemFill(&info, 0, sizeof(info));
-
 	PADDED_STRING_COPY(info.slotDescription, desc);
 	PADDED_STRING_COPY(info.manufacturerID, manuf);
 
@@ -472,7 +463,7 @@ uint32_t entry_ck_slot_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 uint32_t entry_ck_token_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	struct ck_token *token = NULL;
 	const char manuf[] = SKS_CRYPTOKI_TOKEN_MANUFACTURER;
@@ -480,10 +471,7 @@ uint32_t entry_ck_token_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 	const char model[] = SKS_CRYPTOKI_TOKEN_MODEL;
 	const char hwver[] = SKS_CRYPTOKI_TOKEN_HW_VERSION;
 	const char fwver[] = SKS_CRYPTOKI_TOKEN_FW_VERSION;
-	struct sks_token_info info;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
-	TEE_MemFill(&info, 0, sizeof(info));
+	struct sks_token_info info = { };
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -505,8 +493,6 @@ uint32_t entry_ck_token_info(TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 	token = get_token(token_id);
 	if (!token)
 		return SKS_CKR_SLOT_ID_INVALID;
-
-	TEE_MemFill(&info, 0, sizeof(info));
 
 	PADDED_STRING_COPY(info.label, token->db_main->label);
 	PADDED_STRING_COPY(info.manufacturerID, manuf);
@@ -545,13 +531,11 @@ uint32_t entry_ck_token_mecha_ids(TEE_Param *ctrl,
 				  TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	struct ck_token *token = NULL;
 	uint32_t mechanisms_count = (uint32_t)get_supported_mechanisms(NULL, 0);
 	size_t __maybe_unused count = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -789,13 +773,11 @@ uint32_t entry_ck_token_mecha_info(TEE_Param *ctrl,
 				   TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	uint32_t type = 0;
 	struct ck_token *token = NULL;
 	struct sks_mechanism_info *info = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -956,13 +938,11 @@ static uint32_t open_ck_session(uintptr_t tee_session, TEE_Param *ctrl,
 				TEE_Param *in, TEE_Param *out, bool readonly)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	struct ck_token *token = NULL;
 	struct pkcs11_session *session = NULL;
 	struct pkcs11_client *client = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -1082,11 +1062,9 @@ uint32_t entry_ck_token_close_session(uintptr_t tee_session, TEE_Param *ctrl,
 				      TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out || ctrl->memref.size < sizeof(uint32_t))
 		return SKS_BAD_PARAM;
@@ -1110,14 +1088,12 @@ uint32_t entry_ck_token_close_all(uintptr_t tee_session, TEE_Param *ctrl,
 				  TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t token_id = 0;
 	struct ck_token *token = NULL;
 	struct pkcs11_session *session = NULL;
 	struct pkcs11_session *next = NULL;
 	struct pkcs11_client *client = tee_session2client(tee_session);
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -1150,10 +1126,8 @@ static uint32_t set_pin(struct pkcs11_session *session,
 	uint32_t *pin_count = NULL;
 	uint32_t *pin_size = NULL;
 	uint8_t *pin = NULL;
-	TEE_ObjectHandle pin_key_hdl;
+	TEE_ObjectHandle pin_key_hdl = TEE_HANDLE_NULL;
 	uint32_t flag_mask = 0;
-
-	TEE_MemFill(&pin_key_hdl, 0, sizeof(pin_key_hdl));
 
 	if (session->token->db_main->flags & SKS_CKFT_WRITE_PROTECTED)
 		return SKS_CKR_TOKEN_WRITE_PROTECTED;
@@ -1220,13 +1194,11 @@ uint32_t entry_init_pin(uintptr_t tee_session, TEE_Param *ctrl,
 			TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	uint32_t pin_size = 0;
 	void *pin = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -1423,15 +1395,13 @@ uint32_t entry_set_pin(uintptr_t tee_session, TEE_Param *ctrl,
 			TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	uint32_t old_pin_size = 0;
 	uint32_t pin_size = 0;
 	void *old_pin = NULL;
 	void *pin = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -1494,7 +1464,7 @@ uint32_t entry_login(uintptr_t tee_session, TEE_Param *ctrl,
 		     TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct pkcs11_session *sess = NULL;
@@ -1502,8 +1472,6 @@ uint32_t entry_login(uintptr_t tee_session, TEE_Param *ctrl,
 	uint32_t user_type = 0;
 	uint32_t pin_size = 0;
 	void *pin = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -1613,11 +1581,9 @@ uint32_t entry_logout(uintptr_t tee_session, TEE_Param *ctrl,
 		      TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;

--- a/ta/secure_key_services/src/processing.c
+++ b/ta/secure_key_services/src/processing.c
@@ -129,15 +129,13 @@ uint32_t entry_import_object(uintptr_t tee_session,
 			     TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_attrs_head *head = NULL;
 	struct sks_object_head *template = NULL;
 	size_t template_size = 0;
 	uint32_t obj_handle = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	/*
 	 * Collect the arguments of the request
@@ -270,10 +268,10 @@ size_t get_object_key_bit_size(struct sks_object *obj)
 static uint32_t generate_random_key_value(struct sks_attrs_head **head)
 {
 	uint32_t rv = 0;
-	void *data;
-	uint32_t data_size;
-	uint32_t value_len;
-	void *value;
+	void *data = NULL;
+	uint32_t data_size = 0;
+	uint32_t value_len = 0;
+	void *value = NULL;
 
 	if (!*head)
 		return SKS_CKR_TEMPLATE_INCONSISTENT;
@@ -306,7 +304,7 @@ uint32_t entry_generate_secret(uintptr_t tee_session,
 			       TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_attribute_head *proc_params = NULL;
@@ -314,8 +312,6 @@ uint32_t entry_generate_secret(uintptr_t tee_session,
 	struct sks_object_head *template = NULL;
 	size_t template_size = 0;
 	uint32_t obj_handle = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -481,7 +477,7 @@ uint32_t entry_generate_key_pair(uintptr_t teesess,
 				 TEE_Param *ctrl, TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_attribute_head *proc_params = NULL;
@@ -492,8 +488,6 @@ uint32_t entry_generate_key_pair(uintptr_t teesess,
 	uint32_t pubkey_handle = 0;
 	uint32_t privkey_handle = 0;
 	uint32_t *hdl_ptr = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;
@@ -653,14 +647,12 @@ uint32_t entry_processing_init(uintptr_t tee_session, TEE_Param *ctrl,
 				enum processing_func function)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_attribute_head *proc_params = NULL;
 	uint32_t key_handle = 0;
 	struct sks_object *obj = NULL;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || out)
 		return SKS_BAD_PARAM;
@@ -746,12 +738,10 @@ uint32_t entry_processing_step(uintptr_t tee_session, TEE_Param *ctrl,
 				enum processing_step step)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	uint32_t mecha_type = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl)
 		return SKS_BAD_PARAM;
@@ -823,12 +813,10 @@ uint32_t entry_verify_oneshot(uintptr_t tee_session, TEE_Param *ctrl,
 
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	uint32_t mecha_type = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	assert(function == SKS_FUNCTION_VERIFY);
 	if (!ctrl)
@@ -875,19 +863,17 @@ uint32_t entry_derive_key(uintptr_t tee_session, TEE_Param *ctrl,
 			  TEE_Param *in, TEE_Param *out)
 {
 	uint32_t rv = 0;
-	struct serialargs ctrlargs;
+	struct serialargs ctrlargs = { };
 	uint32_t session_handle = 0;
 	struct pkcs11_session *session = NULL;
 	struct sks_attribute_head *proc_params = NULL;
 	uint32_t parent_handle = 0;
-	struct sks_object *parent_obj;
+	struct sks_object *parent_obj = NULL;
 	struct sks_attrs_head *head = NULL;
 	struct sks_object_head *template = NULL;
 	size_t template_size = 0;
 	uint32_t out_handle = 0;
 	uint32_t __maybe_unused mecha_id = 0;
-
-	TEE_MemFill(&ctrlargs, 0, sizeof(ctrlargs));
 
 	if (!ctrl || in || !out)
 		return SKS_BAD_PARAM;

--- a/ta/secure_key_services/src/processing_aes.c
+++ b/ta/secure_key_services/src/processing_aes.c
@@ -18,13 +18,11 @@
 uint32_t tee_init_ctr_operation(struct active_processing *processing,
 				    void *proc_params, size_t params_size)
 {
-	struct serialargs args;
+	struct serialargs args = { };
 	uint32_t rv = 0;
 	/* CTR parameters */
 	uint32_t incr_counter = 0;
 	void *counter_bits = NULL;
-
-	TEE_MemFill(&args, 0, sizeof(args));
 
 	if (!proc_params)
 		return SKS_BAD_PARAM;
@@ -443,7 +441,7 @@ uint32_t tee_init_ccm_operation(struct active_processing *processing,
 {
 	uint32_t rv = 0;
 	struct ae_aes_context *params = NULL;
-	struct serialargs args;
+	struct serialargs args = { };
 	/* CCM parameters */
 	uint32_t data_len = 0;
 	uint32_t nonce_len = 0;
@@ -451,8 +449,6 @@ uint32_t tee_init_ccm_operation(struct active_processing *processing,
 	uint32_t aad_len = 0;
 	void *aad = NULL;
 	uint32_t mac_len = 0;
-
-	TEE_MemFill(&args, 0, sizeof(args));
 
 	if (!proc_params)
 		return SKS_BAD_PARAM;
@@ -554,7 +550,7 @@ void tee_release_ccm_operation(struct active_processing *processing)
 uint32_t tee_init_gcm_operation(struct active_processing *processing,
 				    void *proc_params, size_t params_size)
 {
-	struct serialargs args;
+	struct serialargs args = { };
 	uint32_t rv = 0;
 	uint32_t tag_len = 0;
 	struct ae_aes_context *params = NULL;
@@ -564,8 +560,6 @@ uint32_t tee_init_gcm_operation(struct active_processing *processing,
 	uint32_t aad_len = 0;
 	void *aad = NULL;
 	uint32_t tag_bitlen = 0;
-
-	TEE_MemFill(&args, 0, sizeof(args));
 
 	if (!proc_params)
 		return SKS_BAD_PARAM;

--- a/ta/secure_key_services/src/processing_asymm.c
+++ b/ta/secure_key_services/src/processing_asymm.c
@@ -570,15 +570,13 @@ uint32_t do_asymm_derivation(struct pkcs11_session *session,
 {
 	uint32_t rv = SKS_ERROR;
 	TEE_Result res = TEE_ERROR_GENERIC;
-	TEE_Attribute tee_attrs[2];
+	TEE_Attribute tee_attrs[2] = { };
 	size_t tee_attrs_count = 0;
 	TEE_ObjectHandle out_handle = TEE_HANDLE_NULL;
 	void *a_ptr = NULL;
 	size_t a_size = 0;
 	uint32_t key_bit_size = 0;
 	uint32_t key_byte_size = 0;
-
-	TEE_MemFill(tee_attrs, 0, sizeof(tee_attrs));
 
 	rv = get_u32_attribute(*head, SKS_CKA_VALUE_LEN, &key_bit_size);
 	if (rv)

--- a/ta/secure_key_services/src/processing_ec.c
+++ b/ta/secure_key_services/src/processing_ec.c
@@ -1019,11 +1019,9 @@ uint32_t sks2tee_algo_ecdh(uint32_t *tee_id,
 			   struct sks_attribute_head *proc_params,
 			   struct sks_object *obj)
 {
-	struct serialargs args;
+	struct serialargs args = { };
 	uint32_t rv = 0;
 	uint32_t kdf = 0;
-
-	TEE_MemFill(&args, 0, sizeof(args));
 
 	serialargs_init(&args, proc_params->data, proc_params->size);
 
@@ -1063,11 +1061,9 @@ uint32_t sks2tee_algo_ecdh(uint32_t *tee_id,
 uint32_t sks2tee_ecdh_param_pub(struct sks_attribute_head *proc_params,
 			        void **pub_data, size_t *pub_size)
 {
-	struct serialargs args;
+	struct serialargs args = { };
 	uint32_t rv = 0;
 	uint32_t temp = 0;
-
-	TEE_MemFill(&args, 0, sizeof(args));
 
 	serialargs_init(&args, proc_params->data, proc_params->size);
 
@@ -1176,10 +1172,8 @@ uint32_t generate_ec_keys(struct sks_attribute_head *proc_params,
 	uint32_t tee_size = 0;
 	uint32_t tee_curve = 0;
 	TEE_ObjectHandle tee_obj = TEE_HANDLE_NULL;
-	TEE_Attribute tee_key_attr[1];
+	TEE_Attribute tee_key_attr[1] = { };
 	TEE_Result res = TEE_ERROR_GENERIC;
-
-	TEE_MemFill(tee_key_attr, 0, sizeof(tee_key_attr));
 
 	if (!proc_params || !*pub_head || !*priv_head)
 		return SKS_CKR_TEMPLATE_INCONSISTENT;

--- a/ta/secure_key_services/src/processing_rsa.c
+++ b/ta/secure_key_services/src/processing_rsa.c
@@ -19,10 +19,10 @@
 uint32_t sks2tee_proc_params_rsa_pss(struct active_processing *processing,
 				     struct sks_attribute_head *proc_params)
 {
-	struct serialargs args;
-	uint32_t rv;
-	uint32_t data32;
-	uint32_t salt_len;
+	struct serialargs args = { };
+	uint32_t rv = 0;
+	uint32_t data32 = 0;
+	uint32_t salt_len = 0;
 
 	serialargs_init(&args, proc_params->data, proc_params->size);
 
@@ -57,11 +57,11 @@ void tee_release_rsa_pss_operation(struct active_processing *processing)
 uint32_t sks2tee_algo_rsa_pss(uint32_t *tee_id,
 				struct sks_attribute_head *proc_params)
 {
-	struct serialargs args;
-	uint32_t rv;
-	uint32_t hash;
-	uint32_t mgf;
-	uint32_t salt_len;
+	struct serialargs args = { };
+	uint32_t rv = 0;
+	uint32_t hash = 0;
+	uint32_t mgf = 0;
+	uint32_t salt_len = 0;
 
 	serialargs_init(&args, proc_params->data, proc_params->size);
 
@@ -110,14 +110,14 @@ uint32_t tee_init_rsa_aes_key_wrap_operation(struct active_processing *proc,
 					     void *proc_params,
 					     size_t params_size)
 {
-	struct serialargs args;
-	uint32_t rv;
-	uint32_t aes_bit_size;
-	uint32_t hash;
-	uint32_t mgf;
-	uint32_t source_type;
-	void *source_data;
-	uint32_t source_size;
+	struct serialargs args = { };
+	uint32_t rv = 0;
+	uint32_t aes_bit_size = 0;
+	uint32_t hash = 0;
+	uint32_t mgf = 0;
+	uint32_t source_type = 0;
+	void *source_data = NULL;
+	uint32_t source_size = 0;
 
 	serialargs_init(&args, proc_params, params_size);
 
@@ -153,13 +153,13 @@ uint32_t tee_init_rsa_aes_key_wrap_operation(struct active_processing *proc,
 uint32_t sks2tee_algo_rsa_oaep(uint32_t *tee_id,
 				struct sks_attribute_head *proc_params)
 {
-	struct serialargs args;
-	uint32_t rv;
-	uint32_t hash;
-	uint32_t mgf;
-	uint32_t source_type;
-	void *source_data;
-	uint32_t source_size;
+	struct serialargs args = { };
+	uint32_t rv = 0;
+	uint32_t hash = 0;
+	uint32_t mgf = 0;
+	uint32_t source_type = 0;
+	void *source_data = NULL;
+	uint32_t source_size = 0;
 
 	serialargs_init(&args, proc_params->data, proc_params->size);
 
@@ -233,13 +233,13 @@ uint32_t tee_init_rsa_oaep_operation(struct active_processing *processing,
 uint32_t tee_init_rsa_oaep_operation(struct active_processing *processing,
 				     void *proc_params, size_t params_size)
 {
-	struct serialargs args;
-	uint32_t rv;
-	uint32_t hash;
-	uint32_t mgf;
-	uint32_t source_type;
-	void *source_data;
-	uint32_t source_size;
+	struct serialargs args = { };
+	uint32_t rv = 0;
+	uint32_t hash = 0;
+	uint32_t mgf = 0;
+	uint32_t source_type = 0;
+	void *source_data = NULL;
+	uint32_t source_size = 0;
 
 	serialargs_init(&args, proc_params, params_size);
 
@@ -374,7 +374,7 @@ static uint32_t tee2sks_rsa_attributes(struct sks_attrs_head **pub_head,
 					struct sks_attrs_head **priv_head,
 					TEE_ObjectHandle tee_obj)
 {
-	uint32_t rv;
+	uint32_t rv = 0;
 
 	rv = tee2sks_add_attribute(pub_head, SKS_CKA_MODULUS,
 				   tee_obj, TEE_ATTR_RSA_MODULUS);
@@ -435,13 +435,13 @@ uint32_t generate_rsa_keys(struct sks_attribute_head *proc_params,
 			   struct sks_attrs_head **pub_head,
 			   struct sks_attrs_head **priv_head)
 {
-	uint32_t rv;
-	void *a_ptr;
-	uint32_t a_size;
-	TEE_ObjectHandle tee_obj;
-	TEE_Result res;
-	uint32_t tee_size;
-	TEE_Attribute tee_attrs[1];
+	uint32_t rv = 0;
+	void *a_ptr = NULL;
+	uint32_t a_size = 0;
+	TEE_ObjectHandle tee_obj = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t tee_size = 0;
+	TEE_Attribute tee_attrs[1] = { };
 	uint32_t tee_count = 0;
 
 	if (!proc_params || !*pub_head || !*priv_head) {

--- a/ta/secure_key_services/src/processing_symm.c
+++ b/ta/secure_key_services/src/processing_symm.c
@@ -161,13 +161,11 @@ static uint32_t allocate_tee_operation(struct pkcs11_session *session,
 static uint32_t load_tee_key(struct pkcs11_session *session,
 				struct sks_object *obj)
 {
-	TEE_Attribute tee_attr;
+	TEE_Attribute tee_attr = { };
 	size_t object_size = 0;
 	uint32_t key_type = 0;
 	uint32_t rv = 0;
 	TEE_Result res = TEE_ERROR_GENERIC;
-
-	TEE_MemFill(&tee_attr, 0, sizeof(tee_attr));
 
 	if (obj->key_handle != TEE_HANDLE_NULL) {
 		/* Key was already loaded and fits current need */

--- a/ta/secure_key_services/src/sanitize_object.c
+++ b/ta/secure_key_services/src/sanitize_object.c
@@ -54,18 +54,17 @@ bool sanitize_consistent_class_and_type(struct sks_attrs_head *attrs)
 static uint32_t sanitize_class_and_type(struct sks_attrs_head **dst,
 				     void *src)
 {
-	struct sks_object_head head;
+	struct sks_object_head head = { };
 	char *cur = NULL;
 	char *end = NULL;
 	size_t len = 0;
 	uint32_t class_found = 0;
 	uint32_t type_found = 0;
-	struct sks_attribute_head cli_ref;
+	struct sks_attribute_head cli_ref = { };
 	uint32_t rc = SKS_OK;
 	size_t src_size = 0;
 
 	TEE_MemMove(&head, src, sizeof(head));
-	TEE_MemFill(&cli_ref, 0, sizeof(cli_ref));
 
 	src_size = sizeof(struct sks_object_head) + head.attrs_size;
 
@@ -81,7 +80,7 @@ static uint32_t sanitize_class_and_type(struct sks_attrs_head **dst,
 		len = sizeof(cli_ref) + cli_ref.size;
 
 		if (sks_attr_is_class(cli_ref.id)) {
-			uint32_t class;
+			uint32_t class = 0;
 
 			if (cli_ref.size != sks_attr_is_class(cli_ref.id)) {
 				rc = SKS_CKR_TEMPLATE_INCONSISTENT;
@@ -205,17 +204,16 @@ static uint32_t sanitize_boolprop(struct sks_attrs_head **dst,
 
 static uint32_t sanitize_boolprops(struct sks_attrs_head **dst, void *src)
 {
-	struct sks_object_head head;
+	struct sks_object_head head = { };
 	char *cur = NULL;
 	char *end = NULL;
 	size_t len = 0;
-	struct sks_attribute_head cli_ref;
+	struct sks_attribute_head cli_ref = { };
 	uint32_t sanity[SKS_MAX_BOOLPROP_ARRAY] = { 0 };
 	uint32_t boolprops[SKS_MAX_BOOLPROP_ARRAY] = { 0 };
 	uint32_t rc = 0;
 
 	TEE_MemMove(&head, src, sizeof(head));
-	TEE_MemFill(&cli_ref, 0, sizeof(cli_ref));
 
 	cur = (char *)src + sizeof(struct sks_object_head);
 	end = cur + head.attrs_size;
@@ -276,13 +274,11 @@ static uint32_t sanitize_indirect_attr(struct sks_attrs_head **dst,
 uint32_t sanitize_client_object(struct sks_attrs_head **dst,
 				void *src, size_t size)
 {
-	struct sks_object_head head;
+	struct sks_object_head head = { };
 	uint32_t rc = 0;
 	char *cur = NULL;
 	char *end = NULL;
 	size_t next = 0;
-
-	TEE_MemFill(&head, 0, sizeof(head));
 
 	if (size < sizeof(struct sks_object_head))
 		return SKS_BAD_PARAM;
@@ -306,7 +302,7 @@ uint32_t sanitize_client_object(struct sks_attrs_head **dst,
 	end = cur + head.attrs_size;
 
 	for (; cur < end; cur += next) {
-		struct sks_attribute_head cli_ref;
+		struct sks_attribute_head cli_ref = { };
 
 		TEE_MemMove(&cli_ref, cur, sizeof(cli_ref));
 		next = sizeof(cli_ref) + cli_ref.size;
@@ -367,7 +363,7 @@ static uint32_t __trace_attributes(char *prefix, void *src, void *end)
 	*(prefix2 + prefix_len + 4) = '\0';
 
 	for (; cur < (char *)end; cur += next) {
-		struct sks_ref sks_ref;
+		struct sks_ref sks_ref = { };
 		uint8_t data[4] = { 0 };
 		uint32_t data_u32 = 0;
 
@@ -435,7 +431,7 @@ static uint32_t __trace_attributes(char *prefix, void *src, void *end)
 uint32_t trace_attributes_from_api_head(const char *prefix,
 					void *ref, size_t size)
 {
-	struct sks_object_head head;
+	struct sks_object_head head = { };
 	char *pre = NULL;
 	size_t offset = 0;
 	uint32_t rc = 0;

--- a/ta/secure_key_services/src/serializer.c
+++ b/ta/secure_key_services/src/serializer.c
@@ -92,11 +92,9 @@ uint32_t serialargs_get_ptr(struct serialargs *args, void **out, size_t size)
 uint32_t serialargs_alloc_get_one_attribute(struct serialargs *args __unused,
 					    struct sks_attribute_head **out __unused)
 {
-	struct sks_attribute_head head;
+	struct sks_attribute_head head = { };
 	size_t out_size = sizeof(head);
 	void *pref = NULL;
-
-	TEE_MemFill(&head, 0, sizeof(head));
 
 	if (args->next + out_size > args->start + args->size) {
 		EMSG("arg too short: full %zd, remain %zd, expect at least %zd",
@@ -130,11 +128,9 @@ uint32_t serialargs_alloc_get_one_attribute(struct serialargs *args __unused,
 uint32_t serialargs_alloc_get_attributes(struct serialargs *args __unused,
 					 struct sks_object_head **out __unused)
 {
-	struct sks_object_head attr;
+	struct sks_object_head attr = { };
 	struct sks_object_head *pattr = NULL;
 	size_t attr_size = sizeof(attr);
-
-	TEE_MemFill(&attr, 0, sizeof(attr));
 
 	if (args->next + attr_size > args->start + args->size) {
 		EMSG("arg too short: full %zd, remain %zd, expect at least %zd",


### PR DESCRIPTION
Correct missing initialization of local variables and replace
such initialization with explicit TEE_MemFill() with assignation
to value { } at variable definition which is the preferred way
in OP-TEE.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         documentation/github.md.

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" part:
         https://github.com/OP-TEE/optee_os/blob/master/Notice.md#contributions.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
