### PR TITLE
ta: sks: fix generic secret key size in key generation and derivation

### DIFF
--- a/ta/pkcs11/src/processing.c
+++ b/ta/pkcs11/src/processing.c
@@ -165,9 +165,6 @@ static uint32_t generate_random_key_value(struct pkcs11_attrs_head **head)
 	}
 	TEE_MemMove(&value_len, data, data_size);
 
-	if (get_type(*head) == PKCS11_CKK_GENERIC_SECRET)
-		value_len = (value_len + 7) / 8;
-
 	value = TEE_Malloc(value_len, TEE_USER_MEM_HINT_NO_FILL_ZERO);
 	if (!value)
 		return PKCS11_CKR_DEVICE_MEMORY;

--- a/ta/pkcs11/src/processing_asymm.c
+++ b/ta/pkcs11/src/processing_asymm.c
@@ -630,14 +630,9 @@ uint32_t do_asymm_derivation(struct pkcs11_session *session,
 
 	TEE_MemFill(tee_attrs, 0, sizeof(tee_attrs));
 
-	rv = get_u32_attribute(*head, PKCS11_CKA_VALUE_LEN, &key_bit_size);
+	rv = get_u32_attribute(*head, PKCS11_CKA_VALUE_LEN, &key_byte_size);
 	if (rv)
 		return rv;
-
-	if (get_type(*head) != PKCS11_CKK_GENERIC_SECRET)
-		key_bit_size *= 8;
-
-	key_byte_size = (key_bit_size + 7) / 8;
 
 	res = TEE_AllocateTransientObject(TEE_TYPE_GENERIC_SECRET,
 					  key_byte_size * 8, &out_handle);
@@ -686,7 +681,7 @@ uint32_t do_asymm_derivation(struct pkcs11_session *session,
 	if (rv)
 		goto bail;
 
-	if (a_size * 8 < key_bit_size)
+	if (a_size < key_byte_size)
 		rv = PKCS11_CKR_KEY_SIZE_RANGE;
 	else
 		rv = add_attribute(head, PKCS11_CKA_VALUE, a_ptr,


### PR DESCRIPTION
Fix do_asymm_derivation() and generate_random_key_value(): the key
size defined by attribute VALUE_LEN is always a byte size even for
generic secret objects.

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
[picked from [https://github.com/foundriesio/optee-sks/pull/1](https://github.com/foundriesio/optee-sks/pull/1)]
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
