### PR TITLE
ta: sks: fix return code on one-shot process of a updated operation

### DIFF
--- a/ta/pkcs11/src/pkcs11_attributes.c
+++ b/ta/pkcs11/src/pkcs11_attributes.c
@@ -87,15 +87,23 @@ check_mechanism_against_processing(struct pkcs11_session *session,
 		break;
 
 	case PKCS11_FUNC_STEP_ONESHOT:
+		if (session->processing->always_authen &&
+		    !session->processing->relogged)
+			return PKCS11_CKR_USER_NOT_LOGGED_IN;
+
+		if (session->processing->updated) {
+			EMSG("Cannot perform one-shot on updated processing");
+			return PKCS11_CKR_ARGUMENTS_BAD;
+		}
+		allowed = true;
+		break;
+
 	case PKCS11_FUNC_STEP_UPDATE:
 		if (session->processing->always_authen &&
 		    !session->processing->relogged)
 			return PKCS11_CKR_USER_NOT_LOGGED_IN;
 
-		if (!session->processing->updated)
-			allowed = true;
-		else
-			allowed = !mechanism_is_one_shot_only(mechanism_type);
+		allowed = !mechanism_is_one_shot_only(mechanism_type);
 		break;
 
 	case PKCS11_FUNC_STEP_FINAL:


### PR DESCRIPTION
Fix return value when one-short processing is requested over an operation
that has already gone through a operation update processing. Prior this
change the PKCS11 TA return PKCS11_CKR_KEY_FUNCTION_NOT_PERMITTED which
is not accurate when key permits the operation but not the specification.

For clarity, this change splits one-shot and update steps case in
check_mechanism_against_processing().

Reported-by: Ruchika Gupta <ruchika.gupta@linaro.org>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
