### PR TITLE
[RFC] Proposal for a driver probing sequence

### DIFF
--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -10,6 +10,7 @@
 #include <io.h>
 #include <keep.h>
 #include <kernel/dt.h>
+#include <kernel/dt_driver.h>
 #include <kernel/boot.h>
 #include <kernel/panic.h>
 #include <kernel/spinlock.h>

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -175,7 +175,22 @@ struct clk *clk_dt_get_by_idx(const void *fdt, int nodeoffset,
 	return clk_dt_get_by_idx_prop("clocks", fdt, nodeoffset, clk_idx);
 }
 
-static const struct clk_driver *clk_get_compatible_driver(const char *compat)
+struct clk *clk_dt_get_by_name(const void *fdt, int nodeoffset,
+			       const char *name)
+{
+	int idx = fdt_stringlist_search(fdt, nodeoffset, "clock-names", name);
+
+	if (idx < 0)
+		return NULL;
+
+	return clk_dt_get_by_idx(fdt, nodeoffset, idx);
+}
+
+static TEE_Result clk_probe_clock_provider_node(const void *fdt, int node);
+
+static const struct clk_driver *clk_get_compatible_driver(
+					const char *compat,
+					const struct dt_device_match **out_dm)
 {
 	const struct dt_driver *drv = NULL;
 	const struct dt_device_match *dm = NULL;
@@ -187,8 +202,12 @@ static const struct clk_driver *clk_get_compatible_driver(const char *compat)
 
 		clk_drv = (const struct clk_driver *)drv->driver;
 		for (dm = drv->match_table; dm && dm->compatible; dm++) {
-			if (strcmp(dm->compatible, compat) == 0)
+			if (strcmp(dm->compatible, compat) == 0) {
+				if (out_dm)
+					*out_dm = dm;
+
 				return clk_drv;
+			}
 		}
 	}
 
@@ -240,6 +259,7 @@ static TEE_Result clk_dt_node_clock_setup_driver(const void *fdt, int node)
 	const char *compat = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	const struct clk_driver *clk_drv = NULL;
+	const struct dt_device_match *dm = NULL;
 
 	count = fdt_stringlist_count(fdt, node, "compatible");
 	if (count < 0)
@@ -251,7 +271,7 @@ static TEE_Result clk_dt_node_clock_setup_driver(const void *fdt, int node)
 		if (!compat)
 			return TEE_ERROR_GENERIC;
 
-		clk_drv = clk_get_compatible_driver(compat);
+		clk_drv = clk_get_compatible_driver(compat, &dm);
 		if (!clk_drv)
 			continue;
 

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -25,7 +25,8 @@ static const struct clk_ops fixed_clk_clk_ops = {
 	.get_rate = fixed_clk_get_rate,
 };
 
-static TEE_Result fixed_clock_setup(const void *fdt, int offs)
+static TEE_Result fixed_clock_setup(const void *fdt, int offs,
+				    const void *compat_data __unused)
 {
 	const uint32_t *freq = NULL;
 	const char *name = NULL;

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -25,7 +25,7 @@ static const struct clk_ops fixed_clk_clk_ops = {
 	.get_rate = fixed_clk_get_rate,
 };
 
-static TEE_Result fixed_clock_setup(const void *fdt, int offs,
+static TEE_Result fixed_clock_probe(const void *fdt, int offs,
 				    const void *compat_data __unused)
 {
 	const uint32_t *freq = NULL;
@@ -74,4 +74,4 @@ free_clk:
 	return res;
 }
 
-CLK_DT_DECLARE(fixed_clock, "fixed-clock", fixed_clock_setup);
+CLK_DT_DECLARE(fixed_clock, "fixed-clock", fixed_clock_probe);

--- a/core/drivers/crypto/se050/glue/i2c.c
+++ b/core/drivers/crypto/se050/glue/i2c.c
@@ -85,4 +85,4 @@ static TEE_Result load_trampoline(void)
 	return TEE_SUCCESS;
 }
 
-boot_final(load_trampoline);
+release_init_resource(load_trampoline);

--- a/core/include/drivers/clk_dt.h
+++ b/core/include/drivers/clk_dt.h
@@ -18,9 +18,6 @@
  * @__probe: Clock probe function
  */
 #define CLK_DT_DECLARE(__name, __compat, __probe) \
-	static const struct dt_driver_setup __name ## _driver = { \
-		.probe = __probe, \
-	}; \
 	static const struct dt_device_match __name ## _match_table[] = { \
 		{ .compatible = __compat }, \
 		{ } \
@@ -29,7 +26,7 @@
 		.name = # __name, \
 		.type = DT_DRIVER_CLK, \
 		.match_table = __name ## _match_table, \
-		.driver = &__name ## _driver, \
+		.probe = __probe, \
 	}
 
 /**

--- a/core/include/initcall.h
+++ b/core/include/initcall.h
@@ -42,6 +42,7 @@ struct initcall {
 #define service_init_late(fn)		__define_initcall(init, 4, fn)
 #define driver_init(fn)			__define_initcall(init, 5, fn)
 #define driver_init_late(fn)		__define_initcall(init, 6, fn)
+#define release_init_resource(fn)	__define_initcall(init, 7, fn)
 
 #define boot_final(fn)			__define_initcall(final, 1, fn)
 

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
- * Copyright (c) 2016, Linaro Limited
+ * Copyright (c) 2016-2021, Linaro Limited
  */
 
 #ifndef KERNEL_DT_H
@@ -9,6 +9,7 @@
 #include <compiler.h>
 #include <kernel/panic.h>
 #include <stdint.h>
+#include <tee_api_types.h>
 #include <types_ext.h>
 #include <util.h>
 
@@ -60,11 +61,35 @@ enum dt_driver_type {
 	DT_DRIVER_CLK,
 };
 
+/*
+ * dt_driver_probe_func - Callback probe function for a driver.
+ *
+ * @fdt; FDT base address
+ * @nodeoffset: Offset of the node in the FDT
+ * @compat_data: Data registered for the compatible that probed the device
+ *
+ * Return TEE_SUCCESS on successfull probe,
+ *	TEE_ERROR_ITEM_NOT_FOUND when no driver matched node's compatible string
+ *	Any other TEE_ERROR_* compliant code.
+ */
+typedef TEE_Result (*dt_driver_probe_func)(const void *fdt, int nodeoffset,
+					   const void *compat_data);
+
+/*
+ * Driver instance registered to be probed on compatible node found in the DT.
+ *
+ * @name: Driver name
+ * @type: Drive type
+ * @match_table: Compatible matching identifiers, null terminated
+ * @driver: Driver private reference or NULL
+ * @probe: Probe callback (see dt_driver_probe_func) or NULL
+ */
 struct dt_driver {
 	const char *name;
 	enum dt_driver_type type;
 	const struct dt_device_match *match_table; /* null-terminated */
 	const void *driver;
+	TEE_Result (*probe)(const void *fdt, int node, const void *compat_data);
 };
 
 #define __dt_driver __section(".rodata.dtdrv" __SECTION_FLAGS_RODATA)

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -55,6 +55,7 @@ struct dt_device_match {
 
 enum dt_driver_type {
 	DT_DRIVER_NOTYPE,
+	DT_DRIVER_ANY = DT_DRIVER_NOTYPE,
 	DT_DRIVER_UART,
 	DT_DRIVER_CLK,
 };

--- a/core/include/kernel/dt.h
+++ b/core/include/kernel/dt.h
@@ -50,6 +50,7 @@ struct dt_node_info {
 
 struct dt_device_match {
 	const char *compatible;
+	const void *compat_data;
 };
 
 enum dt_driver_type {

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Copyright (c) 2021, Bootlin
+ * Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, STMicroelectronics
  */
 
 #ifndef __DT_DRIVER_H
@@ -116,4 +118,12 @@ unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);
 
 int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
 			    enum dt_driver_type type);
+
+/*
+ * Called by bus like nodes to propose a node for dt_driver probing
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Node offset on the FDT for the device
+ */
+TEE_Result dt_driver_maybe_add_probe_node(const void *fdt, int nodeoffset);
 #endif /* __DT_DRIVER_H */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -9,6 +9,7 @@
 #include <kernel/dt.h>
 #include <stdint.h>
 #include <sys/queue.h>
+#include <tee_api_types.h>
 
 struct dt_driver_provider;
 
@@ -35,29 +36,6 @@ struct dt_driver_phandle_args {
  */
 typedef void *(get_of_device_func)(struct dt_driver_phandle_args *parg,
 				   void *data);
-
-/*
- * dt_driver_probe_func - Callback probe function for a driver.
- *
- * @fdt; FDT base address
- * @nodeoffset: Offset of the node in the FDT
- * @compat_data: Data registered for the compatible that probed the device
- *
- * Return TEE_SUCCESS on successfull probe,
- *	TEE_ERROR_ITEM_NOT_FOUND when no driver matched node's compatible string
- *	Any other TEE_ERROR_* compliant code.
- */
-typedef TEE_Result (*dt_driver_probe_func)(const void *fdt, int nodeoffset,
-					   const void *compat_data);
-
-/**
- * struct dt_driver_setup - Generic driver setup structure
- * @probe: Refer to typedef'ed dt_driver_probe_func
- */
-struct dt_driver_setup {
-	TEE_Result (*probe)(const void *fdt, int nodeoffset,
-			    const void *compat_data);
-};
 
 /**
  * dt_driver_register_provider - Register a driver provider
@@ -138,6 +116,4 @@ unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);
 
 int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
 			    enum dt_driver_type type);
-
-
 #endif /* __DT_DRIVER_H */

--- a/core/include/kernel/dt_driver.h
+++ b/core/include/kernel/dt_driver.h
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2021, Bootlin
+ */
+
+#ifndef __DT_DRIVER_H
+#define __DT_DRIVER_H
+
+#include <kernel/dt.h>
+#include <stdint.h>
+#include <sys/queue.h>
+
+struct dt_driver_provider;
+
+/**
+ * struct dt_driver_phandle_args - Devicetree clock args
+ * @args_count: Count of cells for the device
+ * @args: Device consumer specifiers
+ */
+struct dt_driver_phandle_args {
+	int args_count;
+	uint32_t args[];
+};
+
+/*
+ * get_of_device_func - Callback function for returning a driver private
+ *	instance based on a FDT phandle with possible arguments and the
+ *	registered dt_driver private data reference.
+ *
+ * @parg: phandle argument(s) referencing the device in the FDT.
+ * @data: driver private data registered in struct dt_driver.
+ *
+ * Return a driver opaque reference, i.e. a struct clk for a clock driver,
+ * or NULL if not found.
+ */
+typedef void *(get_of_device_func)(struct dt_driver_phandle_args *parg,
+				   void *data);
+
+/*
+ * dt_driver_probe_func - Callback probe function for a driver.
+ *
+ * @fdt; FDT base address
+ * @nodeoffset: Offset of the node in the FDT
+ * @compat_data: Data registered for the compatible that probed the device
+ *
+ * Return TEE_SUCCESS on successfull probe,
+ *	TEE_ERROR_ITEM_NOT_FOUND when no driver matched node's compatible string
+ *	Any other TEE_ERROR_* compliant code.
+ */
+typedef TEE_Result (*dt_driver_probe_func)(const void *fdt, int nodeoffset,
+					   const void *compat_data);
+
+/**
+ * struct dt_driver_setup - Generic driver setup structure
+ * @probe: Refer to typedef'ed dt_driver_probe_func
+ */
+struct dt_driver_setup {
+	TEE_Result (*probe)(const void *fdt, int nodeoffset,
+			    const void *compat_data);
+};
+
+/**
+ * dt_driver_register_provider - Register a driver provider
+ *
+ * @fdt: Device tree to work on
+ * @nodeoffset: Node offset of the clock
+ * @get_device: Callback to match the devicetree with a device instance
+ * @data: Data which will be passed to the get_dt_clk callback
+ * Returns TEE_Result value
+ *
+ * @get_device callback return a void *. Driver provider is expected to
+ * include a shim helper to cast to device reference into provider driver
+ * target structure reference (i.e. (struct clk *) for clock devices.
+ */
+TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
+					get_of_device_func *get_of_device,
+					void *data, enum dt_driver_type type);
+
+/*
+ * Return a device instance based on a driver provider and
+ * device phandle and arg property pointer.
+ */
+void *dt_driver_device_from_provider_prop(struct dt_driver_provider *prv,
+					  const uint32_t *prop);
+
+/*
+ * Return a device instance based on a property name and FDT information
+ *
+ * @prop_name: DT property name, i.e. "clocks" for clock resources
+ * @fdt: FDT base address
+ * @nodeoffset: node offset in the FDT
+ * @prop_idx: index of the phandle data in the property
+ */
+void *dt_driver_device_from_node_idx_prop(const char *prop_name,
+					  const void *fdt, int nodeoffset,
+					  unsigned int prop_idx);
+
+/*
+ * Return driver provider reference from its node offset value in the FDT
+ */
+struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset);
+
+/*
+ * Return driver provider reference from its phandle value in the FDT
+ */
+struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle);
+
+/*
+ * Probe matching driver to create a device from a FDT node
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Node byte offset from FDT base
+ * @type: Target driver to match or DT_DRIVER_ANY
+ *
+ * Read the dt_driver database. Compatible list is looked up in the order
+ * of the FDT "compatible" property list. @type can be used to probe only
+ * specific drivers.
+ *
+ */
+TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
+					  enum dt_driver_type type);
+
+/*
+ * Return number cells used for phandle arguments by a driver provider
+ */
+unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv);
+
+/*
+ * Get cells count of a driver related to its dt_driver type
+ *
+ * @fdt: FDT base address
+ * @nodeoffset: Node offset on the FDT for the device
+ * @type: One of the supported DT_DRIVER_* value.
+ *
+ * Currently supports type DT_DRIVER_CLK.
+ * Return a positive cell count value (>= 0) or a negative FDT_ error code
+ */
+
+int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
+			    enum dt_driver_type type);
+
+
+#endif /* __DT_DRIVER_H */

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -652,3 +652,35 @@ static TEE_Result probe_dt_drivers(void)
 }
 
 driver_init(probe_dt_drivers);
+
+/*
+ * Simple bus support: handy to parse subnodes
+ */
+static TEE_Result simple_bus_probe(const void *fdt, int node,
+				   const void *compat_data __unused)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	int subnode = 0;
+
+	fdt_for_each_subnode(subnode, fdt, node) {
+		res = dt_driver_maybe_add_probe_node(fdt, subnode);
+		if (res) {
+			EMSG("Failed on node %s with %#"PRIx32,
+			     fdt_get_name(fdt, subnode, NULL), res);
+			panic();
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+static const struct dt_device_match simple_bus_match_table[] = {
+	{ .compatible = "simple-bus" },
+	{ }
+};
+
+const struct dt_driver simple_bus_dt_driver __dt_driver = {
+	.name = "simple-bus",
+	.match_table = simple_bus_match_table,
+	.probe = simple_bus_probe,
+};

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright (c) 2021, Bootlin
+ * Copyright (c) 2021, Linaro Limited
+ * Copyright (c) 2021, STMicroelectronics
  */
 
 #include <assert.h>
@@ -39,6 +41,18 @@ struct dt_driver_provider {
 static SLIST_HEAD(, dt_driver_provider) dt_driver_provider_list =
 	SLIST_HEAD_INITIALIZER(dt_driver_provider_list);
 
+static void assert_type_is_valid(enum dt_driver_type type)
+{
+	switch (type) {
+	case DT_DRIVER_NOTYPE:
+	case DT_DRIVER_UART:
+	case DT_DRIVER_CLK:
+		return;
+	default:
+		assert(0);
+	}
+}
+
 /*
  * Driver provider registering API functions
  */
@@ -48,6 +62,8 @@ TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
 				       void *priv, enum dt_driver_type type)
 {
 	struct dt_driver_provider *prv = NULL;
+
+	assert_type_is_valid(type);
 
 	prv = calloc(1, sizeof(*prv));
 	if (!prv)
@@ -195,6 +211,10 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 	return NULL;
 }
 
+static TEE_Result alloc_elt_and_probe(const void *fdt, int node,
+				      const struct dt_driver *dt_drv,
+				      const struct dt_device_match *dm);
+
 /* Lookup a compatible driver, possibly of a specific @type, for the FDT node */
 static TEE_Result probe_device_by_compat(const void *fdt, int node,
 					 const char *compat,
@@ -209,12 +229,16 @@ static TEE_Result probe_device_by_compat(const void *fdt, int node,
 
 		for (dm = drv->match_table; dm && dm->compatible; dm++)
 			if (strcmp(dm->compatible, compat) == 0)
-				return drv->probe(fdt, node, dm->compat_data);
+				return alloc_elt_and_probe(fdt, node, drv, dm);
 	}
 
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
 
+/*
+ * Lookup the best matching compatible driver, possibly of a specific @type,
+ * for the FDT node.
+ */
 TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
 					  enum dt_driver_type type)
 {
@@ -223,6 +247,8 @@ TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
 	int count = 0;
 	const char *compat = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
+
+	assert_type_is_valid(type);
 
 	count = fdt_stringlist_count(fdt, nodeoffset, "compatible");
 	if (count < 0)
@@ -242,3 +268,387 @@ TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
 
 	return TEE_ERROR_ITEM_NOT_FOUND;
 }
+
+/*
+ * Build driver probing list: 1 element per node to probe a driver for
+ */
+struct dt_driver_probe {
+	TAILQ_ENTRY(dt_driver_probe) link;
+
+	enum dt_driver_type type;
+	int nodeoffset;
+	const struct dt_driver *dt_drv;
+	const struct dt_device_match *dm;
+	unsigned int deferrals;
+};
+
+/*
+ * Monitoring the probe list. Elements are added when parsing and possibly
+ * probing drivers for device node. Non matching elements are removed during
+ * that DT nodes parsing loop.
+ *
+ * @added_count: increments when a new element is added to the list
+ */
+struct probe_list_info {
+	unsigned int added_count;
+};
+
+static struct probe_list_info probe_list_info;
+
+static TAILQ_HEAD(dt_driver_probe_head, dt_driver_probe) dt_driver_probe_list =
+	TAILQ_HEAD_INITIALIZER(dt_driver_probe_list);
+
+static TAILQ_HEAD(, dt_driver_probe) dt_driver_ready_list =
+	TAILQ_HEAD_INITIALIZER(dt_driver_ready_list);
+
+static void add_to_ready_list(struct dt_driver_probe *elt)
+{
+	TAILQ_INSERT_HEAD(&dt_driver_ready_list, elt, link);
+}
+
+static void add_to_probe_list(struct dt_driver_probe *elt)
+{
+	TAILQ_INSERT_TAIL(&dt_driver_probe_list, elt, link);
+}
+
+static void remove_from_probe_list(struct dt_driver_probe *elt)
+{
+	TAILQ_REMOVE(&dt_driver_probe_list, elt, link);
+}
+
+static unsigned int __maybe_unused probe_list_count(void)
+{
+	struct dt_driver_probe *elt = NULL;
+	unsigned int count = 0;
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		count++;
+
+	return count;
+}
+
+static void __maybe_unused print_probe_list(const void *fdt __maybe_unused)
+{
+	struct dt_driver_probe *elt = NULL;
+
+	DMSG("Probe list: %u elements, %u added since startpoint",
+	     probe_list_count(), probe_list_info.added_count);
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		DMSG("- Driver %s probes on node %s",
+		     elt->dt_drv->name,
+		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+
+	DMSG("Probe list end");
+}
+
+static bool is_already_in_probe_list(struct dt_driver_probe *candidate)
+{
+	struct dt_driver_probe *elt = NULL;
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link) {
+		if (elt->nodeoffset == candidate->nodeoffset &&
+		    elt->type ==  candidate->type) {
+			assert(elt->dt_drv == candidate->dt_drv);
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool is_already_in_ready_list(struct dt_driver_probe *candidate)
+{
+	struct dt_driver_probe *elt = NULL;
+
+	TAILQ_FOREACH(elt, &dt_driver_ready_list, link) {
+		if (elt->nodeoffset == candidate->nodeoffset &&
+		    elt->type ==  candidate->type) {
+			assert(elt->dt_drv == candidate->dt_drv);
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ * Probe element: push to ready list if succeeds, push to probe list if busy,
+ * panic with an error trace otherwise.
+ */
+static TEE_Result probe_driver_node(const void *fdt, struct dt_driver_probe *elt)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const char __maybe_unused *drv_name = NULL;
+	const char __maybe_unused *node_name = NULL;
+
+	node_name = fdt_get_name(fdt, elt->nodeoffset, NULL);
+	drv_name = elt->dt_drv->name;
+	FMSG("Probing %s on node %s", drv_name, node_name);
+
+	res = elt->dt_drv->probe(fdt, elt->nodeoffset, elt->dm->compat_data);
+	switch (res) {
+	case TEE_SUCCESS:
+		DMSG("element: %s on node %s intialized", drv_name, node_name);
+		add_to_ready_list(elt);
+		break;
+	case TEE_ERROR_BUSY:
+		elt->deferrals++;
+		DMSG("element: %s on node %s deferred %u time(s)", drv_name,
+		     node_name, elt->deferrals);
+		add_to_probe_list(elt);
+		break;
+	default:
+		EMSG("Fail to probe %s on node %s: %#"PRIx32,
+		     drv_name, node_name, res);
+		panic();
+	}
+
+	return res;
+}
+
+static TEE_Result alloc_elt_and_probe(const void *fdt, int node,
+				      const struct dt_driver *dt_drv,
+				      const struct dt_device_match *dm)
+{
+	struct dt_driver_probe *elt = NULL;
+
+	/* Will be freed when lists are released */
+	elt = calloc(1, sizeof(*elt));
+	if (!elt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	elt->nodeoffset = node;
+	elt->dt_drv = dt_drv;
+	elt->dm = dm;
+	elt->type = dt_drv->type;
+
+	return probe_driver_node(fdt, elt);
+}
+
+static TEE_Result process_probe_list(const void *fdt)
+{
+	struct dt_driver_probe *elt = NULL;
+	struct dt_driver_probe *prev = NULL;
+	unsigned int __maybe_unused loop_count = 0;
+	unsigned int __maybe_unused deferral_loop_count = 0;
+
+	while (1) {
+		unsigned int added_count = probe_list_info.added_count;
+		bool all_deferred = true;
+		bool one_deferred = false;
+
+		loop_count++;
+		FMSG("Probe loop %u after %u for deferral(s)", loop_count,
+		     deferral_loop_count);
+
+		/* Hack here for TRACE_DEBUG messages on probe list elements */
+		if (TRACE_LEVEL >= TRACE_FLOW)
+			print_probe_list(fdt);
+
+		if (TAILQ_EMPTY(&dt_driver_probe_list))
+			return TEE_SUCCESS;
+
+		/*
+		 * Probe from current end to top. Deferred probed node are
+		 * pushed back after current tail for the next probe round.
+		 */
+		TAILQ_FOREACH_REVERSE_SAFE(elt, &dt_driver_probe_list,
+					   dt_driver_probe_head, link, prev) {
+			remove_from_probe_list(elt);
+
+			switch (probe_driver_node(fdt, elt)) {
+			case TEE_SUCCESS:
+				all_deferred = false;
+				break;
+			case TEE_ERROR_BUSY:
+				one_deferred = true;
+				break;
+			default:
+				assert(0);
+			}
+
+		}
+
+		if (one_deferred)
+			deferral_loop_count++;
+
+		if (all_deferred && added_count == probe_list_info.added_count)
+			break;
+	}
+
+	EMSG("Panic on unresolved dependencies after %u rounds, %u deferred:",
+	     loop_count, deferral_loop_count);
+
+	TAILQ_FOREACH(elt, &dt_driver_probe_list, link)
+		EMSG("- %s on node %s", elt->dt_drv->name,
+		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+
+	panic();
+}
+
+/*
+ * Return TEE_SUCCESS if compatible found
+ *	  TEE_ERROR_OUT_OF_MEMORY if heap is exhausted
+ */
+static TEE_Result add_node_to_probe(const void *fdt, int node,
+				    const struct dt_driver *dt_drv,
+				    const struct dt_device_match *dm)
+{
+	const char __maybe_unused *node_name = fdt_get_name(fdt, node, NULL);
+	const char __maybe_unused *drv_name = dt_drv->name;
+	struct dt_driver_probe *elt = NULL;
+	struct dt_driver_probe elt_temp = {
+		.dm = dm,
+		.dt_drv = dt_drv,
+		.nodeoffset = node,
+		.type = dt_drv->type,
+	};
+
+	if (is_already_in_probe_list(&elt_temp)) {
+		FMSG("element: %s on node %s already in probe list",
+		     node_name, drv_name);
+		return TEE_SUCCESS;
+	}
+	if (is_already_in_ready_list(&elt_temp)) {
+		FMSG("element: %s on node %s already ready",
+		     node_name, drv_name);
+		return TEE_SUCCESS;
+	}
+
+	elt = malloc(sizeof(*elt));
+	if (!elt)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	DMSG("element: %s on node %s", node_name, drv_name);
+
+	memcpy(elt, &elt_temp, sizeof(*elt));
+
+	probe_list_info.added_count++;
+
+	add_to_probe_list(elt);
+
+	/* Hack here for TRACE_DEBUG messages on current probe list elements */
+	if (TRACE_LEVEL >= TRACE_FLOW)
+		print_probe_list(fdt);
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Add a node to the probe list if a dt_driver matches target compatible.
+ *
+ * If @type is DT_DRIVER_ANY, probe list can hold only 1 driver to probe for
+ * the node. A node may probe several drivers if have a unique driver type.
+ *
+ * Return TEE_SUCCESS if compatible found
+ *	  TEE_ERROR_ITEM_NOT_FOUND if no matching driver
+ *	  TEE_ERROR_OUT_OF_MEMORY if heap is exhausted
+ */
+static TEE_Result add_probe_node_by_compat(const void *fdt, int node,
+					   const char *compat)
+{
+	TEE_Result res = TEE_ERROR_ITEM_NOT_FOUND;
+	const struct dt_driver *dt_drv = NULL;
+	const struct dt_device_match *dm = NULL;
+	uint32_t found_types = 0;
+
+	for_each_dt_driver(dt_drv) {
+		for (dm = dt_drv->match_table; dm && dm->compatible; dm++) {
+			if (strcmp(dm->compatible, compat) == 0) {
+				assert(dt_drv->type < 32);
+
+				res = add_node_to_probe(fdt, node, dt_drv, dm);
+				if (res)
+					return res;
+
+				if (found_types & BIT(dt_drv->type)) {
+					EMSG("Driver %s multi hit on type %u",
+					     dt_drv->name, dt_drv->type);
+					panic();
+				}
+				found_types |= BIT(dt_drv->type);
+
+				/* Matching found for this driver, try next */
+				break;
+			}
+		}
+	}
+
+	return res;
+}
+
+/*
+ * Add the node to the probe list if matching compatible drivers are found.
+ * Follow node's compatible property list ordering to find matching driver.
+ */
+TEE_Result dt_driver_maybe_add_probe_node(const void *fdt, int node)
+{
+	int idx = 0;
+	int len = 0;
+	int count = 0;
+	const char *compat = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (_fdt_get_status(fdt, node) == DT_STATUS_DISABLED)
+		return TEE_SUCCESS;
+
+	count = fdt_stringlist_count(fdt, node, "compatible");
+	if (count < 0)
+		return TEE_SUCCESS;
+
+	for (idx = 0; idx < count; idx++) {
+		compat = fdt_stringlist_get(fdt, node, "compatible", idx, &len);
+		assert(compat && len > 0);
+
+		res = add_probe_node_by_compat(fdt, node, compat);
+
+		/* Stop lookup if something was found */
+		if (res != TEE_ERROR_ITEM_NOT_FOUND)
+			return res;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static void parse_node(const void *fdt, int node)
+{
+	TEE_Result __maybe_unused res = TEE_ERROR_GENERIC;
+	int subnode = 0;
+
+	fdt_for_each_subnode(subnode, fdt, node) {
+		res = dt_driver_maybe_add_probe_node(fdt, subnode);
+		if (res) {
+			EMSG("Failed on node %s with %#"PRIx32,
+			     fdt_get_name(fdt, subnode, NULL), res);
+			panic();
+		}
+
+		/* Rescursively parse the FDT, skipping disabled nodes */
+		if (IS_ENABLED(CFG_DRIVERS_DT_RECURSIVE_PROBE)) {
+			if (_fdt_get_status(fdt, subnode) == DT_STATUS_DISABLED)
+				continue;
+
+			parse_node(fdt, subnode);
+		}
+	}
+}
+
+/*
+ * Parse FDT for nodes and save in probe list the node for which a dt_driver
+ * matches node's compatible property.
+ */
+static TEE_Result probe_dt_drivers(void)
+{
+	const void *fdt = get_embedded_dt();
+	int root_node = fdt_path_offset(fdt, "/");
+
+	assert(fdt);
+	parse_node(fdt, root_node);
+
+	return process_probe_list(fdt);
+}
+
+driver_init(probe_dt_drivers);

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -195,25 +195,21 @@ void *dt_driver_device_from_node_idx_prop(const char *prop_name,
 	return NULL;
 }
 
-static TEE_Result probe_device_by_compat(const void *fdt, int nodeoffset,
+/* Lookup a compatible driver, possibly of a specific @type, for the FDT node */
+static TEE_Result probe_device_by_compat(const void *fdt, int node,
 					 const char *compat,
 					 enum dt_driver_type type)
 {
 	const struct dt_driver *drv = NULL;
 	const struct dt_device_match *dm = NULL;
-	const struct dt_driver_setup *drv_setup = NULL;
 
 	for_each_dt_driver(drv) {
 		if (drv->type != type)
 			continue;
 
-		drv_setup = (const struct dt_driver_setup *)drv->driver;
-		assert(drv_setup);
-
 		for (dm = drv->match_table; dm && dm->compatible; dm++)
 			if (strcmp(dm->compatible, compat) == 0)
-				return drv_setup->probe(fdt, nodeoffset,
-							dm->compat_data);
+				return drv->probe(fdt, node, dm->compat_data);
 	}
 
 	return TEE_ERROR_ITEM_NOT_FOUND;

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -94,7 +94,8 @@ static TEE_Result dt_driver_release_provider(void)
 
 	return TEE_SUCCESS;
 }
-driver_init_late(dt_driver_release_provider);
+
+release_init_resource(dt_driver_release_provider);
 
 /*
  * Helper functions for dt_drivers quering driver provider information
@@ -652,6 +653,25 @@ static TEE_Result probe_dt_drivers(void)
 }
 
 driver_init(probe_dt_drivers);
+
+static TEE_Result release_probe_lists(void)
+{
+	struct dt_driver_probe *elt = NULL;
+	struct dt_driver_probe *next = NULL;
+	const void * __maybe_unused fdt = get_embedded_dt();
+
+	assert(fdt && TAILQ_EMPTY(&dt_driver_probe_list));
+
+	TAILQ_FOREACH_SAFE(elt, &dt_driver_ready_list, link, next) {
+		DMSG("element: %s on node %s", elt->dt_drv->name,
+		     fdt_get_name(fdt, elt->nodeoffset, NULL));
+		free(elt);
+	}
+
+	return TEE_SUCCESS;
+}
+
+release_init_resource(release_probe_lists);
 
 /*
  * Simple bus support: handy to parse subnodes

--- a/core/kernel/dt_driver.c
+++ b/core/kernel/dt_driver.c
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2021, Bootlin
+ */
+
+#include <assert.h>
+#include <config.h>
+#include <initcall.h>
+#include <kernel/boot.h>
+#include <kernel/dt.h>
+#include <kernel/dt_driver.h>
+#include <kernel/panic.h>
+#include <libfdt.h>
+#include <stddef.h>
+
+/*
+ * struct dt_driver_provider - DT related info on probed device
+ *
+ * Saves information on the probed device so that device
+ * drivers can get resources from DT phandle and related arguments.
+ *
+ * @nodeoffset: node offset of device referenced in the FDT
+ * @type: one of DT_DRIVER_* or DT_DRIVER_NOTYPE.
+ * @provider_cells: cells count in the FDT used by the driver's references
+ * @get_of_device: callback to get driver's device reference from phandle data
+ * @priv_data: driver private data reference passed as @get_of_device() argument
+ * @link: Reference in DT driver providers list
+ */
+struct dt_driver_provider {
+	int nodeoffset;
+	enum dt_driver_type type;
+	unsigned int provider_cells;
+	uint32_t phandle;
+	void *(*get_of_device)(struct dt_driver_phandle_args *parg, void *priv);
+	void *priv_data;
+	SLIST_ENTRY(dt_driver_provider) link;
+};
+
+static SLIST_HEAD(, dt_driver_provider) dt_driver_provider_list =
+	SLIST_HEAD_INITIALIZER(dt_driver_provider_list);
+
+/*
+ * Driver provider registering API functions
+ */
+
+TEE_Result dt_driver_register_provider(const void *fdt, int nodeoffset,
+				       get_of_device_func *get_of_device,
+				       void *priv, enum dt_driver_type type)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	prv = calloc(1, sizeof(*prv));
+	if (!prv)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	prv->type = type;
+	prv->priv_data = priv;
+	prv->nodeoffset = nodeoffset;
+	prv->get_of_device = get_of_device;
+	prv->provider_cells = fdt_get_dt_driver_cells(fdt, nodeoffset, type);
+	prv->phandle = fdt_get_phandle(fdt, nodeoffset);
+
+	SLIST_INSERT_HEAD(&dt_driver_provider_list, prv, link);
+
+	return TEE_SUCCESS;
+}
+
+/* Release driver provider references once all dt_drivers are initialized */
+static TEE_Result dt_driver_release_provider(void)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	while (!SLIST_EMPTY(&dt_driver_provider_list)) {
+		prv = SLIST_FIRST(&dt_driver_provider_list);
+		SLIST_REMOVE_HEAD(&dt_driver_provider_list, link);
+		free(prv);
+	}
+
+	return TEE_SUCCESS;
+}
+driver_init_late(dt_driver_release_provider);
+
+/*
+ * Helper functions for dt_drivers quering driver provider information
+ */
+
+int fdt_get_dt_driver_cells(const void *fdt, int nodeoffset,
+			    enum dt_driver_type type)
+{
+	const fdt32_t *c = NULL;
+	int len = 0;
+
+	switch (type) {
+	case DT_DRIVER_CLK:
+		c = fdt_getprop(fdt, nodeoffset, "#clock-cells", &len);
+		break;
+	default:
+		panic();
+	}
+
+	if (!c)
+		return len;
+
+	if (len != sizeof(*c))
+		return -FDT_ERR_BADNCELLS;
+
+	return fdt32_to_cpu(*c);
+}
+
+unsigned int dt_driver_provider_cells(struct dt_driver_provider *prv)
+{
+	return prv->provider_cells;
+}
+
+struct dt_driver_provider *dt_driver_get_provider_by_node(int nodeoffset)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
+		if (prv->nodeoffset == nodeoffset)
+			return prv;
+
+	return NULL;
+}
+
+struct dt_driver_provider *dt_driver_get_provider_by_phandle(uint32_t phandle)
+{
+	struct dt_driver_provider *prv = NULL;
+
+	SLIST_FOREACH(prv, &dt_driver_provider_list, link)
+		if (prv->phandle == phandle)
+			return prv;
+
+	return NULL;
+}
+
+void *dt_driver_device_from_provider_prop(struct dt_driver_provider *prv,
+					  const uint32_t *prop)
+{
+	struct dt_driver_phandle_args *pargs = NULL;
+	unsigned int n = 0;
+	void *device = NULL;
+
+	pargs = calloc(1, prv->provider_cells * sizeof(uint32_t *) +
+		       sizeof(*pargs));
+
+	pargs->args_count = prv->provider_cells;
+	for (n = 0; n < prv->provider_cells; n++)
+		pargs->args[n] = fdt32_to_cpu(prop[n + 1]);
+
+	device = prv->get_of_device(pargs, prv->priv_data);
+
+	free(pargs);
+
+	return device;
+}
+
+void *dt_driver_device_from_node_idx_prop(const char *prop_name,
+					  const void *fdt, int nodeoffset,
+					  unsigned int prop_idx)
+{
+	int len = 0;
+	int idx = 0;
+	int idx32 = 0;
+	int prv_cells = 0;
+	uint32_t phandle = 0;
+	const uint32_t *prop = NULL;
+	struct dt_driver_provider *prv = NULL;
+	void *ref = NULL;
+
+	prop = fdt_getprop(fdt, nodeoffset, prop_name, &len);
+	if (!prop)
+		return NULL;
+
+	while (idx < len) {
+		idx32 = idx / sizeof(uint32_t);
+		phandle = fdt32_to_cpu(prop[idx32]);
+
+		prv = dt_driver_get_provider_by_phandle(phandle);
+		if (!prv)
+			return NULL;
+
+		prv_cells = dt_driver_provider_cells(prv);
+		if (prop_idx) {
+			prop_idx--;
+			idx += sizeof(phandle) + prv_cells * sizeof(uint32_t);
+			continue;
+		}
+
+		ref = dt_driver_device_from_provider_prop(prv, prop + idx32);
+
+		return (struct clk *)ref;
+	}
+
+	return NULL;
+}
+
+static TEE_Result probe_device_by_compat(const void *fdt, int nodeoffset,
+					 const char *compat,
+					 enum dt_driver_type type)
+{
+	const struct dt_driver *drv = NULL;
+	const struct dt_device_match *dm = NULL;
+	const struct dt_driver_setup *drv_setup = NULL;
+
+	for_each_dt_driver(drv) {
+		if (drv->type != type)
+			continue;
+
+		drv_setup = (const struct dt_driver_setup *)drv->driver;
+		assert(drv_setup);
+
+		for (dm = drv->match_table; dm && dm->compatible; dm++)
+			if (strcmp(dm->compatible, compat) == 0)
+				return drv_setup->probe(fdt, nodeoffset,
+							dm->compat_data);
+	}
+
+	return TEE_ERROR_ITEM_NOT_FOUND;
+}
+
+TEE_Result dt_driver_probe_device_by_node(const void *fdt, int nodeoffset,
+					  enum dt_driver_type type)
+{
+	int idx = 0;
+	int len = 0;
+	int count = 0;
+	const char *compat = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	count = fdt_stringlist_count(fdt, nodeoffset, "compatible");
+	if (count < 0)
+		return TEE_ERROR_ITEM_NOT_FOUND;
+
+	for (idx = 0; idx < count; idx++) {
+		compat = fdt_stringlist_get(fdt, nodeoffset, "compatible",
+					    idx, &len);
+		if (!compat)
+			return TEE_ERROR_GENERIC;
+
+		res = probe_device_by_compat(fdt, nodeoffset, compat, type);
+
+		if (res != TEE_ERROR_ITEM_NOT_FOUND)
+			return res;
+	}
+
+	return TEE_ERROR_ITEM_NOT_FOUND;
+}

--- a/core/kernel/sub.mk
+++ b/core/kernel/sub.mk
@@ -3,6 +3,7 @@ cflags-remove-asan.c-y += $(cflags_kasan)
 srcs-y += assert.c
 srcs-y += console.c
 srcs-$(CFG_DT) += dt.c
+srcs-$(CFG_DT) += dt_driver.c
 srcs-y += pm.c
 srcs-y += handle.c
 srcs-y += interrupt.c


### PR DESCRIPTION
Propose a driver probing sequence for compatible drivers registered as dt_drivers. introduces **core/kernel/dt_drivers.c** (proposal). A part of the clock framework moves to dt_driver.c for reuse with other drivers.

"core: dt: add platform data per compatible identifier"
"core: factorize dt_driver probing helper function"
"drivers: fixed_clk: rename setup callback to probe"
"core: dt: move probe callback to dt_driver"  ---_DT parsing and processing loop at driver_init_
"core: dt_driver: add simple bus driver"    ---_simple bus node usually probes soc description, allowing depper child-nodes discovery_

Shared here until clk framework P-R is merged.