### PR TITLE
[RFC] Clock orphans : small clock units (half size) to consume less memory

### DIFF
--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -230,6 +230,14 @@ struct clk *clk_get_parent(struct clk *clk)
 	return clk->parent;
 }
 
+size_t clk_get_num_parents(struct clk *clk)
+{
+	if (clk_is_clk_elt(clk))
+		return to_clk_elt(clk)->num_parents;
+
+	return 0;
+}
+
 static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 				     size_t *pidx)
 {

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -101,9 +101,15 @@ TEE_Result clk_register(struct clk *clk)
 	clk_init_parent(clk);
 	clk_compute_rate_no_lock(clk);
 
-	DMSG("Registered clock %s, freq %lu", clk->name, clk_get_rate(clk));
+	DMSG("Registered clock %s, freq %lu", clk_get_name(clk),
+	     clk_get_rate(clk));
 
 	return TEE_SUCCESS;
+}
+
+const char *clk_get_name(struct clk *clk)
+{
+	return clk->name;
 }
 
 static bool clk_is_enabled_no_lock(struct clk *clk)
@@ -235,7 +241,9 @@ static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 			return TEE_SUCCESS;
 		}
 	}
-	EMSG("Clock %s is not a parent of clock %s", parent->name, clk->name);
+
+	EMSG("Clock %s is not a parent of clock %s", clk_get_name(parent),
+	     clk_get_name(clk);
 
 	return TEE_ERROR_BAD_PARAMETERS;
 }

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -17,22 +17,28 @@ static unsigned int clk_lock = SPINLOCK_UNLOCK;
 struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 		      struct clk **parent_clks, size_t parent_count)
 {
-	struct clk *clk = NULL;
+	struct clk_elt *clk_elt = NULL;
 	size_t parent = 0;
 
-	clk = calloc(1, sizeof(*clk) + parent_count * sizeof(clk));
-	if (!clk)
+	if (ops->id != CLK_OPS_ELT) {
+		EMSG("Panic on unexpected ops ID %u", ops->id);
+		panic();
+	}
+
+	clk_elt = calloc(1, sizeof(*clk_elt) +
+			 parent_count * sizeof(*parent_clks));
+	if (!clk_elt)
 		return NULL;
 
-	clk->num_parents = parent_count;
+	clk_elt->num_parents = parent_count;
 	for (parent = 0; parent < parent_count; parent++)
-		clk->parents[parent] = parent_clks[parent];
+		clk_elt->parents[parent] = parent_clks[parent];
 
-	clk->name = name;
-	clk->ops = ops;
-	refcount_set(&clk->enabled_count, 0);
+	clk_elt->name = name;
+	clk_elt->clk.ops = ops;
+	refcount_set(&clk_elt->clk.enabled_count, 0);
 
-	return clk;
+	return (struct clk *)clk_elt;
 }
 
 void clk_free(struct clk *clk)
@@ -45,11 +51,17 @@ static bool __maybe_unused clk_check(struct clk *clk)
 	if (!clk->ops)
 		return false;
 
-	if (clk->ops->set_parent && !clk->ops->get_parent)
-		return false;
+	if (clk_is_clk_elt(clk)) {
+		struct clk_elt *clk_elt = clk_to_clk_elt(clk);
 
-	if (clk->num_parents > 1 && !clk->ops->get_parent)
+		if (clk->ops->set_parent && !clk->ops->get_parent)
+			return false;
+
+		if (clk_elt->num_parents > 1 && !clk->ops->get_parent)
+			return false;
+	} else {
 		return false;
+	}
 
 	return true;
 }
@@ -58,8 +70,8 @@ static void clk_compute_rate_no_lock(struct clk *clk)
 {
 	unsigned long parent_rate = 0;
 
-	if (clk->parent)
-		parent_rate = clk->parent->rate;
+	if (clk_is_clk_elt(clk) && clk_to_clk_elt(clk)->parent)
+		parent_rate = clk_to_clk_elt(clk)->parent->rate;
 
 	if (clk->ops->get_rate)
 		clk->rate = clk->ops->get_rate(clk, parent_rate);
@@ -69,27 +81,31 @@ static void clk_compute_rate_no_lock(struct clk *clk)
 
 struct clk *clk_get_parent_by_index(struct clk *clk, size_t pidx)
 {
-	if (pidx >= clk->num_parents)
+	if (!clk_is_clk_elt(clk))
 		return NULL;
 
-	return clk->parents[pidx];
+	if (pidx >= clk_to_clk_elt(clk)->num_parents)
+		return NULL;
+
+	return clk_to_clk_elt(clk)->parents[pidx];
 }
 
 static void clk_init_parent(struct clk *clk)
 {
+	struct clk_elt *clk_elt = clk_to_clk_elt(clk);
 	size_t pidx = 0;
 
-	switch (clk->num_parents) {
+	switch (clk_elt->num_parents) {
 	case 0:
 		break;
 	case 1:
-		clk->parent = clk->parents[0];
+		clk_elt->parent = clk_elt->parents[0];
 		break;
 	default:
 		pidx = clk->ops->get_parent(clk);
-		assert(pidx < clk->num_parents);
+		assert(pidx < clk_elt->num_parents);
 
-		clk->parent = clk->parents[pidx];
+		clk_elt->parent = clk_elt->parents[pidx];
 		break;
 	}
 }
@@ -98,7 +114,9 @@ TEE_Result clk_register(struct clk *clk)
 {
 	assert(clk_check(clk));
 
-	clk_init_parent(clk);
+	if (clk_is_clk_elt(clk))
+		clk_init_parent(clk);
+
 	clk_compute_rate_no_lock(clk);
 
 	DMSG("Registered clock %s, freq %lu", clk_get_name(clk),
@@ -109,7 +127,10 @@ TEE_Result clk_register(struct clk *clk)
 
 const char *clk_get_name(struct clk *clk)
 {
-	return clk->name;
+	if (clk_is_clk_elt(clk))
+		return clk_to_clk_elt(clk)->name;
+
+	return NULL;
 }
 
 static bool clk_is_enabled_no_lock(struct clk *clk)
@@ -140,11 +161,13 @@ static TEE_Result clk_enable_no_lock(struct clk *clk)
 	if (refcount_inc(&clk->enabled_count))
 		return TEE_SUCCESS;
 
-	parent = clk_get_parent(clk);
-	if (parent) {
-		res = clk_enable_no_lock(parent);
-		if (res)
-			return res;
+	if (clk_is_clk_elt(clk)) {
+		parent = clk_get_parent(clk);
+		if (parent) {
+			res = clk_enable_no_lock(parent);
+			if (res)
+				return res;
+		}
 	}
 
 	if (clk->ops->enable) {
@@ -167,7 +190,7 @@ TEE_Result clk_enable(struct clk *clk)
 	uint32_t exceptions = 0;
 	TEE_Result res = TEE_ERROR_GENERIC;
 
-	exceptions =  cpu_spin_lock_xsave(&clk_lock);
+	exceptions = cpu_spin_lock_xsave(&clk_lock);
 	res = clk_enable_no_lock(clk);
 	cpu_spin_unlock_xrestore(&clk_lock, exceptions);
 
@@ -178,7 +201,7 @@ void clk_disable(struct clk *clk)
 {
 	uint32_t exceptions = 0;
 
-	exceptions =  cpu_spin_lock_xsave(&clk_lock);
+	exceptions = cpu_spin_lock_xsave(&clk_lock);
 	clk_disable_no_lock(clk);
 	cpu_spin_unlock_xrestore(&clk_lock, exceptions);
 }
@@ -193,8 +216,12 @@ static TEE_Result clk_set_rate_no_lock(struct clk *clk, unsigned long rate)
 	TEE_Result res = TEE_ERROR_GENERIC;
 	unsigned long parent_rate = 0;
 
-	if (clk->parent)
-		parent_rate = clk_get_rate(clk->parent);
+	if (clk_is_clk_elt(clk)) {
+		struct clk_elt *clk_elt = clk_to_clk_elt(clk);
+
+		if (clk_elt->parent)
+			parent_rate = clk_get_rate(clk_elt->parent);
+	}
 
 	res = clk->ops->set_rate(clk, rate, parent_rate);
 	if (res)
@@ -211,11 +238,12 @@ TEE_Result clk_set_rate(struct clk *clk, unsigned long rate)
 	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (!clk->ops->set_rate)
-		return TEE_ERROR_NOT_SUPPORTED;
+		return TEE_ERROR_BAD_PARAMETERS;
 
 	exceptions =  cpu_spin_lock_xsave(&clk_lock);
 
-	if (clk->flags & CLK_SET_RATE_GATE && clk_is_enabled_no_lock(clk))
+	if (clk_to_clk_elt(clk)->flags & CLK_SET_RATE_GATE &&
+	    clk_is_enabled_no_lock(clk))
 		res = TEE_ERROR_BAD_STATE;
 	else
 		res = clk_set_rate_no_lock(clk, rate);
@@ -227,13 +255,16 @@ TEE_Result clk_set_rate(struct clk *clk, unsigned long rate)
 
 struct clk *clk_get_parent(struct clk *clk)
 {
-	return clk->parent;
+	if (clk_is_clk_elt(clk))
+		return clk_to_clk_elt(clk)->parent;
+
+	return NULL;
 }
 
 size_t clk_get_num_parents(struct clk *clk)
 {
 	if (clk_is_clk_elt(clk))
-		return to_clk_elt(clk)->num_parents;
+		return clk_to_clk_elt(clk)->num_parents;
 
 	return 0;
 }
@@ -243,6 +274,9 @@ static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 {
 	size_t i = 0;
 
+	if (clk_is_clk_elt(clk))
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	for (i = 0; i < clk_get_num_parents(clk); i++) {
 		if (clk_get_parent_by_index(clk, i) == parent) {
 			*pidx = i;
@@ -251,7 +285,7 @@ static TEE_Result clk_get_parent_idx(struct clk *clk, struct clk *parent,
 	}
 
 	EMSG("Clock %s is not a parent of clock %s", clk_get_name(parent),
-	     clk_get_name(clk);
+	     clk_get_name(clk));
 
 	return TEE_ERROR_BAD_PARAMETERS;
 }
@@ -261,9 +295,10 @@ static TEE_Result clk_set_parent_no_lock(struct clk *clk, struct clk *parent,
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	bool was_enabled = false;
+	struct clk_elt *clk_elt = clk_to_clk_elt(clk);
 
 	/* Requested parent is already the one set */
-	if (clk->parent == parent)
+	if (clk_elt->parent == parent)
 		return TEE_SUCCESS;
 
 	was_enabled = clk_is_enabled_no_lock(clk);
@@ -275,7 +310,7 @@ static TEE_Result clk_set_parent_no_lock(struct clk *clk, struct clk *parent,
 	if (res)
 		goto out;
 
-	clk->parent = parent;
+	clk_elt->parent = parent;
 
 	/* The parent changed and the rate might also have changed */
 	clk_compute_rate_no_lock(clk);
@@ -296,17 +331,21 @@ TEE_Result clk_set_parent(struct clk *clk, struct clk *parent)
 	size_t pidx = 0;
 	uint32_t exceptions = 0;
 	TEE_Result res = TEE_ERROR_GENERIC;
+	struct clk_elt *clk_elt = NULL;
 
-	if (clk_get_parent_idx(clk, parent, &pidx) || !clk->ops->set_parent)
+	if (!clk->ops->set_parent)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	exceptions = cpu_spin_lock_xsave(&clk_lock);
-	if (clk->flags & CLK_SET_PARENT_GATE && clk_is_enabled_no_lock(clk)) {
-		res = TEE_ERROR_BAD_STATE;
-		goto out;
-	}
+	if (clk_get_parent_idx(clk, parent, &pidx))
+		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = clk_set_parent_no_lock(clk, parent, pidx);
+	clk_elt = clk_to_clk_elt(clk);
+
+	exceptions = cpu_spin_lock_xsave(&clk_lock);
+	if (clk_elt->flags & CLK_SET_PARENT_GATE && clk_is_enabled_no_lock(clk))
+		res = TEE_ERROR_BAD_STATE;
+	else
+		res = clk_set_parent_no_lock(clk, parent, pidx);
 out:
 	cpu_spin_unlock_xrestore(&clk_lock, exceptions);
 

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -336,7 +336,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (parent) {
 			if (clk_set_parent(clk, parent)) {
 				EMSG("Could not set clk %s parent to clock %s",
-				     clk->name, parent->name);
+				     clk_get_name(clk), clk_get_name(parent));
 				panic();
 			}
 		}

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -331,6 +331,11 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (!clk)
 			return;
 
+		if (!clk_is_clk_elt(clk)) {
+			EMSG("Can't assign orphan clock %s", clk_get_name(clk));
+			panic();
+		}
+
 		parent = clk_dt_get_by_idx_prop("assigned-clock-parents", fdt,
 						nodeoffset, clock_idx);
 		if (parent) {

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -7,10 +7,12 @@
 #include <drivers/clk_dt.h>
 #include <libfdt.h>
 #include <malloc.h>
+#include <mm/core_memprot.h>
 #include <stdint.h>
 
 struct fixed_clock_data {
 	unsigned long rate;
+	const char *name;
 };
 
 static unsigned long fixed_clk_get_rate(struct clk *clk,
@@ -21,10 +23,19 @@ static unsigned long fixed_clk_get_rate(struct clk *clk,
 	return d->rate;
 }
 
+static const char *fixed_clk_get_name(struct clk *clk)
+{
+	struct fixed_clock_data *d = clk->priv;
+
+	return d->name;
+}
+
 static const struct clk_ops fixed_clk_clk_ops = {
-	.id = CLK_OPS_ELT,
+	.id = CLK_OPS_ORPHAN,
 	.get_rate = fixed_clk_get_rate,
+	.get_name = fixed_clk_get_name,
 };
+DECLARE_KEEP_PAGER(fixed_clk_ops);
 
 static TEE_Result fixed_clock_setup(const void *fdt, int offs)
 {
@@ -33,42 +44,56 @@ static TEE_Result fixed_clock_setup(const void *fdt, int offs)
 	struct clk *clk = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct fixed_clock_data *fcd = NULL;
+	char *dup_name = NULL;
 
 	name = fdt_get_name(fdt, offs, NULL);
 	if (!name)
 		name = "fixed-clock";
 
-	clk = clk_alloc(name, &fixed_clk_clk_ops, NULL, 0);
-	if (!clk)
-		return TEE_ERROR_OUT_OF_MEMORY;
+	if (!is_unpaged((void *)name)) {
+		dup_name = strdup(name);
+		if (!dup_name) {
+			res = TEE_ERROR_OUT_OF_MEMORY;
+			goto err;
+		}
+		name = dup_name;
+	}
+
+	clk = clk_alloc_orphans(&fixed_clk_clk_ops, 1);
+	if (!clk) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
 
 	fcd = calloc(1, sizeof(struct fixed_clock_data));
 	if (!fcd) {
 		res = TEE_ERROR_OUT_OF_MEMORY;
-		goto free_clk;
+		goto err;
 	}
 
 	freq = fdt_getprop(fdt, offs, "clock-frequency", NULL);
 	if (!freq) {
 		res = TEE_ERROR_BAD_FORMAT;
-		goto free_fcd;
+		goto err;
 	}
 
 	fcd->rate = fdt32_to_cpu(*freq);
+	fcd->name = name;
+
 	clk->priv = fcd;
 
 	res = clk_register(clk);
 	if (res)
-		goto free_fcd;
+		goto err;
 
 	res = clk_dt_register_clk_provider(fdt, offs, clk_dt_get_simple_clk,
 					   clk);
 	if (!res)
 		return TEE_SUCCESS;
 
-free_fcd:
+err:
+	free(dup_name);
 	free(fcd);
-free_clk:
 	clk_free(clk);
 
 	return res;

--- a/core/drivers/clk/fixed_clk.c
+++ b/core/drivers/clk/fixed_clk.c
@@ -22,6 +22,7 @@ static unsigned long fixed_clk_get_rate(struct clk *clk,
 }
 
 static const struct clk_ops fixed_clk_clk_ops = {
+	.id = CLK_OPS_ELT,
 	.get_rate = fixed_clk_get_rate,
 };
 

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -142,10 +142,7 @@ struct clk *clk_get_parent(struct clk *clk);
  * @clk: Clock for which the number of parents is needed
  * Return the number of parents
  */
-static inline size_t clk_get_num_parents(struct clk *clk)
-{
-	return clk->num_parents;
-}
+size_t clk_get_num_parents(struct clk *clk);
 
 /**
  * Get a clock parent by its index

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -66,10 +66,7 @@ struct clk_ops {
  * @clk: Clock for which the name is needed
  * Return a const char* pointing to the clock name
  */
-static inline const char *clk_get_name(struct clk *clk)
-{
-	return clk->name;
-}
+const char *clk_get_name(struct clk *clk);
 
 /**
  * clk_alloc - Allocate a clock structure

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -20,10 +20,14 @@
  *
  * CLK_OP_ELT identies a full fledged clock. The struct clk * reference can be
  * cast to struct clk_elt * to access clock element data.
+ *
+ * CLK_OP_ORPHAN identifes a simple clock without parents. struct clk fully
+ * represents the clock.
  */
 enum clk_ops_id {
 	CLK_OPS_INVALID = 0,
 	CLK_OPS_ELT,
+	CLK_OPS_ORPHAN,
 };
 
 /**
@@ -81,6 +85,7 @@ struct clk_ops {
 			       unsigned long parent_rate);
 	unsigned long (*get_rate)(struct clk *clk,
 				  unsigned long parent_rate);
+	const char *(*get_name)(struct clk *clk);
 };
 
 /*
@@ -96,6 +101,11 @@ static inline struct clk_elt *clk_to_clk_elt(struct clk *clk)
 	assert(clk_is_clk_elt(clk));
 
 	return (struct clk_elt *)clk;
+}
+
+static inline bool clk_is_clk_orphan(struct clk *clk)
+{
+	return clk->ops->id == CLK_OPS_ORPHAN;
 }
 
 /**
@@ -120,6 +130,16 @@ const char *clk_get_name(struct clk *clk);
  */
 struct clk *clk_alloc(const char *name, const struct clk_ops *ops,
 		      struct clk **parent_clks, size_t parent_count);
+
+/**
+ * clk_alloc_orphans - Allocate an array of orphan clocks (1 or more)
+ *
+ * @ops: Clock operations
+ * @count: Number of clocks
+ *
+ * Returns a clock struct properly initialized or NULL if allocation failed
+ */
+struct clk *clk_alloc_orphans(const struct clk_ops *ops, size_t count);
 
 /**
  * clk_free - Free a clock structure


### PR DESCRIPTION
A proposal for lowering the memory consumption of clock instance.
I feel that clock framework will someday add features to clock registering, possibly enlarging more the `struct clk` memory footprint. This is painful for platforms with a small secure RAM.

This series proposes the define the 2 types `struct clk` of fixed small size and `struct clk_elt` that add the parent support.
2 preparatory changes in header file followed by the new clock structures, in 2 commits: introduce clk_elt type and clk_orpha type.

"drivers: clk: move clk_get_name() implement in C source"
"drivers: clk: move clk_get_num_parents() implement in C source"
"drivers: clk: prepare for orphan clocks"
"drivers: clk: introduce orphan clocks"
"drivers: clk: move fixed clock to orphan clocks"

One can see here https://github.com/etienne-lms/optee_os/commit/308a316733ec402414662f09ab4d261eefb0e14c how stm32mp1 clock driver can register (orphan) clocks and a clock provider, on top of Clément's patches.