### PR TITLE
[RFC] Clock weak core

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -108,6 +108,9 @@ $(call force,CFG_SCMI_MSG_SMT,y)
 $(call force,CFG_SCMI_MSG_VOLTAGE_DOMAIN,y)
 endif
 
+# Default disable RCC security
+CFG_STM32_RCC_NON_SECURE ?= y
+
 # Default enable some test facitilites
 CFG_TEE_CORE_EMBED_INTERNAL_TESTS ?= y
 CFG_WITH_STATS ?= y

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_clk.c
@@ -4,7 +4,10 @@
  */
 
 #include <assert.h>
+#include <config.h>
 #include <drivers/stm32mp1_rcc.h>
+#include <drivers/clk.h>
+#include <drivers/clk_dt.h>
 #include <dt-bindings/clock/stm32mp1-clks.h>
 #include <initcall.h>
 #include <io.h>
@@ -1231,7 +1234,7 @@ static const char *stm32mp_osc_node_label[NB_OSC] = {
 	[_USB_PHY_48] = "ck_usbo_48m"
 };
 
-static unsigned int clk_freq_prop(void *fdt, int node)
+static unsigned int clk_freq_prop(const void *fdt, int node)
 {
 	const fdt32_t *cuint = NULL;
 	int ret = 0;
@@ -1247,7 +1250,7 @@ static unsigned int clk_freq_prop(void *fdt, int node)
 	return fdt32_to_cpu(*cuint);
 }
 
-static void get_osc_freq_from_dt(void *fdt)
+static void get_osc_freq_from_dt(const void *fdt)
 {
 	enum stm32mp_osc_id idx = _UNKNOWN_OSC_ID;
 	int clk_node = fdt_path_offset(fdt, "/clocks");
@@ -1299,28 +1302,22 @@ static void enable_static_secure_clocks(void)
 		stm32_clock_enable(RTCAPB);
 }
 
-static TEE_Result stm32mp1_clk_early_init(void)
+static void enable_rcc_tzen(void)
 {
-	void *fdt = NULL;
-	int node = 0;
+	io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+}
+
+static void disable_rcc_tzen(void)
+{
+	IMSG("RCC is non-secure");
+	io_clrbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
+}
+
+static TEE_Result stm32mp1_clk_init(const void *fdt, int node)
+{
 	unsigned int i = 0;
 	int len = 0;
 	int ignored = 0;
-
-	fdt = get_embedded_dt();
-	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_CLK_COMPAT);
-
-	if (node < 0 || _fdt_reg_base_address(fdt, node) != RCC_BASE)
-		panic();
-
-	if (_fdt_get_status(fdt, node) & DT_STATUS_OK_SEC) {
-		io_setbits32(stm32_rcc_base() + RCC_TZCR, RCC_TZCR_TZEN);
-	} else {
-		if (io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN)
-			panic("Refuse to release RCC[TZEN]");
-
-		IMSG("RCC is non-secure");
-	}
 
 	get_osc_freq_from_dt(fdt);
 
@@ -1366,5 +1363,156 @@ static TEE_Result stm32mp1_clk_early_init(void)
 	return TEE_SUCCESS;
 }
 
+static TEE_Result stm32mp1_clk_early_init(void)
+{
+	void *fdt = get_embedded_dt();
+	int node = 0;
+	bool rcc_secure = true;
+
+	if (IS_ENABLED(CFG_DRIVERS_CLK) && IS_ENABLED(CFG_DRIVERS_CLK_DT))
+		return TEE_SUCCESS;
+
+	node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_SECURE_CLK_COMPAT);
+	if (node < 0) {
+		node = fdt_node_offset_by_compatible(fdt, -1, DT_RCC_CLK_COMPAT);
+		if (node < 0)
+			panic();
+
+		rcc_secure = false;
+	}
+
+	assert(_fdt_reg_base_address(fdt, node) == RCC_BASE);
+	assert(_fdt_get_status(fdt, node) & DT_STATUS_OK_SEC);
+
+	if (IS_ENABLED(CFG_STM32_RCC_NON_SECURE) || !rcc_secure) {
+		if (io_read32(stm32_rcc_base() + RCC_TZCR) & RCC_TZCR_TZEN)
+			panic("Refuse to release RCC[TZEN]");
+
+		disable_rcc_tzen();
+	} else {
+		enable_rcc_tzen();
+	}
+
+	return stm32mp1_clk_init(fdt, node);
+}
 service_init(stm32mp1_clk_early_init);
+
+#ifdef _CFG_DRIVERS_CLK_WEAK
+/*
+ * Clock driver API functions
+ */
+static void assert_clk_is_valid(struct clk *clk)
+{
+	uintptr_t va __maybe_unused = (uintptr_t)clk;
+	uintptr_t base __maybe_unused = (uintptr_t)stm32mp1_clk_gate;
+	uintptr_t end __maybe_unused = base + sizeof(stm32mp1_clk_gate);
+
+	assert(va >= base && va < end &&
+	       ((va - base) % sizeof(struct stm32mp1_clk_gate)) == 0);
+}
+
+/* Convert the opaque struct clk reference into driver private clock ID */
+static unsigned int clk2clock_id(struct clk *clk)
+{
+	struct stm32mp1_clk_gate *ref = (void *)clk;
+
+	assert_clk_is_valid(clk);
+
+	return ref->clock_id;
+}
+
+/* Convert the driver private clock ID into its opaque struct clk reference */
+static struct clk *clock_id2clk(unsigned int clock_id)
+{
+	size_t n = 0;
+
+	for (n = 0; n < ARRAY_SIZE(stm32mp1_clk_gate); n++)
+		if (stm32mp1_clk_gate[n].clock_id == clock_id)
+			return (struct clk *)(void *)(stm32mp1_clk_gate + n);
+
+	return NULL;
+}
+
+unsigned int stm32_clock_clk2id(struct clk *clk)
+{
+	return clk2clock_id(clk);
+}
+
+const char *clk_get_name(struct clk *clk __maybe_unused)
+{
+	static const char no_name[] = "n.a";
+
+	assert_clk_is_valid(clk);
+
+	return no_name;
+}
+
+unsigned long clk_get_rate(struct clk *clk)
+{
+	unsigned int clock_id = clk2clock_id(clk);
+
+	return stm32_clock_get_rate(clock_id);
+}
+
+TEE_Result clk_enable(struct clk *clk)
+{
+	unsigned int clock_id = clk2clock_id(clk);
+
+	stm32_clock_enable(clock_id);
+
+	return TEE_SUCCESS;
+}
+
+void clk_disable(struct clk *clk)
+{
+	unsigned int clock_id = clk2clock_id(clk);
+
+	stm32_clock_disable(clock_id);
+}
+
+static struct clk *stm32mp1_clk_dt_get_clk(struct dt_driver_phandle_args *pargs,
+					    void *data __unused)
+{
+	if (pargs->args_count != 1)
+		return NULL;
+
+	IMSG("dt get clock: found clock %u", pargs->args[0]);
+
+	return clock_id2clk(pargs->args[0]);
+}
+
+static const uint8_t non_secure_rcc;
+
+static TEE_Result stm32mp1_clock_provider_probe(const void *fdt, int offs,
+						const void *compat_data)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (IS_ENABLED(CFG_STM32_RCC_NON_SECURE) ||
+	    compat_data == &non_secure_rcc)
+		disable_rcc_tzen();
+	else
+		enable_rcc_tzen();
+
+	res = stm32mp1_clk_init(fdt, offs);
+	if (res)
+		return res;
+
+	return clk_dt_register_clk_provider(fdt, offs, stm32mp1_clk_dt_get_clk,
+					    NULL);
+}
+
+static const struct dt_device_match stm32mp1_clock_match_table[] = {
+	{  .compatible = "st,stm32mp1-rcc", .compat_data = &non_secure_rcc, },
+	{  .compatible = "st,stm32mp1-rcc-secure", },
+	{ }
+};
+
+const struct dt_driver stm32mp1_clock_dt_driver __dt_driver = {
+	.name = "stm32mp1_clock",
+	.type = DT_DRIVER_CLK,
+	.match_table = stm32mp1_clock_match_table,
+	.probe = stm32mp1_clock_provider_probe,
+};
+#endif /*_CFG_DRIVERS_CLK_WEAK*/
 #endif /*CFG_EMBED_DTB*/

--- a/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
+++ b/core/arch/arm/plat-stm32mp1/drivers/stm32mp1_rcc.h
@@ -541,7 +541,8 @@
 #define RCC_MP_IWDGFZSETR_IWDG1			BIT(0)
 #define RCC_MP_IWDGFZSETR_IWDG2			BIT(1)
 
-#define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"
+#define DT_RCC_CLK_COMPAT		"st,stm32mp1-rcc"
+#define DT_RCC_SECURE_CLK_COMPAT	"st,stm32mp1-rcc-secure"
 
 #ifndef __ASSEMBLER__
 vaddr_t stm32_rcc_base(void);

--- a/core/arch/arm/plat-stm32mp1/stm32_util.h
+++ b/core/arch/arm/plat-stm32mp1/stm32_util.h
@@ -7,6 +7,7 @@
 #define __STM32_UTIL_H__
 
 #include <assert.h>
+#include <drivers/clk.h>
 #include <drivers/stm32_bsec.h>
 #include <kernel/panic.h>
 #include <stdint.h>
@@ -70,6 +71,17 @@ void stm32_clock_enable(unsigned long id);
 void stm32_clock_disable(unsigned long id);
 unsigned long stm32_clock_get_rate(unsigned long id);
 bool stm32_clock_is_enabled(unsigned long id);
+
+#ifdef _CFG_DRIVERS_CLK_WEAK
+unsigned int stm32_clock_clk2id(struct clk *clk);
+#else
+static inline unsigned int stm32_clock_clk2id(struct clk *clk __unused)
+{
+	assert(0);
+
+	return ~0;
+}
+#endif
 
 /* Return true if @clock_id is shared by secure and non-secure worlds */
 bool stm32mp_nsec_can_access_clock(unsigned long clock_id);

--- a/core/drivers/clk/clk.c
+++ b/core/drivers/clk/clk.c
@@ -40,6 +40,11 @@ void clk_free(struct clk *clk)
 	free(clk);
 }
 
+const char *clk_get_name(struct clk *clk)
+{
+	return clk->name;
+}
+
 static bool __maybe_unused clk_check(struct clk *clk)
 {
 	if (!clk->ops)
@@ -217,6 +222,11 @@ TEE_Result clk_set_rate(struct clk *clk, unsigned long rate)
 	cpu_spin_unlock_xrestore(&clk_lock, exceptions);
 
 	return res;
+}
+
+size_t clk_get_num_parents(struct clk *clk)
+{
+	return clk->num_parents;
 }
 
 struct clk *clk_get_parent(struct clk *clk)

--- a/core/drivers/clk/clk_dt.c
+++ b/core/drivers/clk/clk_dt.c
@@ -336,7 +336,7 @@ static void parse_assigned_clock(const void *fdt, int nodeoffset)
 		if (parent) {
 			if (clk_set_parent(clk, parent)) {
 				EMSG("Could not set clk %s parent to clock %s",
-				     clk->name, parent->name);
+				     clk_get_name(clk), clk_get_name(parent));
 				panic();
 			}
 		}

--- a/core/drivers/clk/clk_weak.c
+++ b/core/drivers/clk/clk_weak.c
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: (BSD-2-Clause)
+/*
+ * Copyright (C) 2021, Linaro Limited
+ */
+
+#include <drivers/clk.h>
+#include <tee_api_defines.h>
+
+/* Weak functions for the clock driver. Platform implements the needed API */
+
+const char __weak *clk_get_name(struct clk *clk __unused)
+{
+	static const char no_name[] = "n.a";
+
+	return no_name;
+}
+
+unsigned long __weak clk_get_rate(struct clk *clk __unused)
+{
+	return 0;
+}
+
+TEE_Result __weak clk_set_rate(struct clk *clk __unused,
+			       unsigned long rate __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+TEE_Result __weak clk_enable(struct clk *clk __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+void __weak clk_disable(struct clk *clk __unused)
+{
+}
+
+struct clk __weak *clk_get_parent(struct clk *clk __unused)
+{
+	return NULL;
+}
+
+size_t __weak clk_get_num_parents(struct clk *clk __unused)
+{
+	return 0;
+}
+
+struct clk __weak *clk_get_parent_by_index(struct clk *clk __unused,
+					   size_t pidx __unused)
+{
+	return NULL;
+}
+
+TEE_Result __weak clk_set_parent(struct clk *clk __unused,
+				 struct clk *parent __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}

--- a/core/drivers/clk/sub.mk
+++ b/core/drivers/clk/sub.mk
@@ -1,3 +1,4 @@
-srcs-y += clk.c
+srcs-$(CFG_DRIVERS_CLK_CORE) += clk.c
+srcs-$(_CFG_DRIVERS_CLK_WEAK) += clk_weak.c
 srcs-$(CFG_DRIVERS_CLK_DT) += clk_dt.c
 srcs-$(CFG_DRIVERS_CLK_FIXED) += fixed_clk.c

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -39,6 +39,6 @@ srcs-$(CFG_IMX_RNGB) += imx_rngb.c
 
 subdirs-y += crypto
 subdirs-$(CFG_BNXT_FW) += bnxt
-subdirs-$(CFG_DRIVERS_CLK) += clk
+subdirs-y += clk
 subdirs-$(CFG_SCMI_MSG_DRIVERS) += scmi-msg
 subdirs-y += imx

--- a/core/include/drivers/clk.h
+++ b/core/include/drivers/clk.h
@@ -14,6 +14,7 @@
 #define CLK_SET_RATE_GATE	BIT(0) /* must be gated across rate change */
 #define CLK_SET_PARENT_GATE	BIT(1) /* must be gated across re-parent */
 
+#ifdef CFG_DRIVERS_CLK_CORE
 /**
  * struct clk - Clock structure
  *
@@ -61,17 +62,6 @@ struct clk_ops {
 };
 
 /**
- * Return the clock name
- *
- * @clk: Clock for which the name is needed
- * Return a const char* pointing to the clock name
- */
-static inline const char *clk_get_name(struct clk *clk)
-{
-	return clk->name;
-}
-
-/**
  * clk_alloc - Allocate a clock structure
  *
  * @name: Clock name
@@ -98,6 +88,21 @@ void clk_free(struct clk *clk);
  * Returns a TEE_Result compliant value
  */
 TEE_Result clk_register(struct clk *clk);
+#else
+/*
+ * struct clk is an opaque structure known from the platform clock provider.
+ * plat_clk_*() function prototypes strictly match their clk_*() counterpart.
+ */
+struct clk;
+#endif /* CFG_DRIVERS_CLK_CORE */
+
+/**
+ * Return the clock name
+ *
+ * @clk: Clock for which the name is needed
+ * Return a const char* pointing to the clock name
+ */
+const char *clk_get_name(struct clk *clk);
 
 /**
  * clk_get_rate - Get clock rate
@@ -145,10 +150,7 @@ struct clk *clk_get_parent(struct clk *clk);
  * @clk: Clock for which the number of parents is needed
  * Return the number of parents
  */
-static inline size_t clk_get_num_parents(struct clk *clk)
-{
-	return clk->num_parents;
-}
+size_t clk_get_num_parents(struct clk *clk);
 
 /**
  * Get a clock parent by its index
@@ -167,5 +169,4 @@ struct clk *clk_get_parent_by_index(struct clk *clk, size_t pidx);
  * Returns a TEE_Result compliant value
  */
 TEE_Result clk_set_parent(struct clk *clk, struct clk *parent);
-
 #endif /* __DRIVERS_CLK_H */

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -692,12 +692,20 @@ $(error CFG_HWRNG_QUALITY not defined)
 endif
 endif
 
-# When enabled, CFG_DRIVERS_CLK embeds a clock framework in OP-TEE core.
+# When enabled, CFG_DRIVERS_CLK embeds a clock framwork in OP-TEE core.
 # This clock framework allows to describe clock tree and provide functions to
 # get and configure the clocks.
+# CFG_DRIVERS_CLK_CORE embeds the generic clock driver implementation
 # CFG_DRIVERS_CLK_DT embeds devicetree clock parsing support
-# CFG_DRIVERS_CLK_FIXED add support for "fixed-clock" compatible clocks
+# CFG_DRIVERS_CLK_FIXED adds support for "fixed-clock" compatible clocks
 CFG_DRIVERS_CLK ?= n
+CFG_DRIVERS_CLK_CORE ?= $(CFG_DRIVERS_CLK)
 CFG_DRIVERS_CLK_DT ?= $(call cfg-all-enabled,CFG_DRIVERS_CLK CFG_DT)
-$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DRIVERS_CLK CFG_DT))
-CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_DT)
+$(eval $(call cfg-depends-all,CFG_DRIVERS_CLK_DT,CFG_DT CFG_DRIVERS_CLK))
+CFG_DRIVERS_CLK_FIXED ?= $(CFG_DRIVERS_CLK_CORE)
+
+ifeq ($(CFG_DRIVERS_CLK),y)
+ifneq ($(CFG_DRIVERS_CLK_CORE),y)
+_CFG_DRIVERS_CLK_WEAK = y
+endif
+endif


### PR DESCRIPTION
Following https://github.com/etienne-lms/optee_os/pull/28, this is another proposal for lowering the memory consumption of clock instance.

This proposal is quite rude. It allows a unique platform clock driver to server the generic clock API `clk_xxx()` and abstract `struct clk`. If the platform clock driver is optimized for memory size, there's no memory consumption overhead due to `struct clk` memory footprint when many clocks are exposed.

This series is made of 2 changes. The first introduces config switches for weak clock API functions. The second shows how stm32mp1 clock driver can match this to register as a standard clock driver bypass clk core for **all** clocks management. Updating stm32mp1 drivers to use the clk API is out of scope of these examples.

"drivers: clk: platform optimized clock provider"
"plat-stm32mp1: clk: implement _CFG_DRIVERS_CLK_WEAK=y"