### PR TITLE
plat-stm32mp1: read HUK from BSEC OTPs

### DIFF
--- a/core/arch/arm/plat-stm32mp1/plat_huk.c
+++ b/core/arch/arm/plat-stm32mp1/plat_huk.c
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2022, Linaro Limited
+ *
+ * Example of implementation to retrieve device HUK from BSEC OPT words.
+ * HUK is expected to be a 16 bytes value, stored in 4 contiguous BSEC words.
+ * This code relies on 3 configuration switches
+ *
+ * CFG_STM32MP1_HUK_BSEC_SHADOW_TESTKEY is a boolean switch (y|n). When
+ *      enable, HUK BSEC shadow register are overridden with an all 0's
+ *      test key.
+ */
+
+#include <assert.h>
+#include <config.h>
+#include <drivers/stm32_bsec.h>
+#include <kernel/panic.h>
+#include <kernel/tee_common_otp.h>
+#include <string.h>
+
+#if !defined(CFG_STM32MP1_HUK_BSEC_BASE) || \
+    !defined(CFG_STM32MP1_HUK_BSEC_COUNT)
+#error "Missing CFG_STM32MP1_HUK_BSEC_BASE and/or CFG_STM32MP1_HUK_BSEC_COUNT"
+#endif
+
+TEE_Result tee_otp_get_hw_unique_key(struct tee_hw_unique_key *huk)
+{
+	static bool initialized = false;
+
+	const uint32_t bsec_base_id = CFG_STM32MP1_HUK_BSEC_BASE;
+-	const size_t bsec_huk_count = CFG_STM32MP1_HUK_BSEC_COUNT;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t bsec_word = 0;
+	bool is_huk_zero = true;
+	size_t n = 0;
+
+	static_assert(CFG_STM32MP1_HUK_BSEC_COUNT * sizeof(uint32_t) ==
+		      sizeof(huk->data));
+
+	if (!initialized) {
+		/* Load BSEC HUK words in shadow memory once for all */
+		for (n = 0; n < bsec_huk_count; n++) {
+			res = stm32_bsec_shadow_register(bsec_base_id + n);
+			if (res)
+				return res;
+		}
+
+		if (IS_ENABLED(CFG_STM32MP1_HUK_BSEC_SHADOW_TESTKEY)) {
+			/* Write testkey (all 0's) in BSEC shadow registers */
+			bsec_word = 0;
+
+			for (n = 0; n < bsec_huk_count; n++) {
+				res = stm32_bsec_write_otp(bsec_word,
+							   bsec_base_id + n);
+				if (res) {
+					IMSG("Can't shadow HUK test key: %#"PRIx32,
+					     res);
+					return res;
+				}
+			}
+
+			IMSG("BSEC OTPs for HUK shadowed with test key");
+		}
+
+		initialized = true;
+	}
+
+	/* Read HUK from BSEC shadow memory */
+	for (n = 0; n < bsec_huk_count; n++) {
+		res = stm32_bsec_read_otp(&bsec_word, bsec_base_id + n);
+		if (res)
+			return res;
+
+		memcpy(huk->data + n * sizeof(uint32_t), &bsec_word,
+		       sizeof(uint32_t));
+	}
+
+	return TEE_SUCCESS;
+}

--- a/core/arch/arm/plat-stm32mp1/sub.mk
+++ b/core/arch/arm/plat-stm32mp1/sub.mk
@@ -3,6 +3,7 @@ global-incdirs-y += .
 srcs-y += main.c
 srcs-y += reset.S
 srcs-$(CFG_SCMI_MSG_DRIVERS) += scmi_server.c
+srcs-$(CFG_STM32MP1_HUK_BSEC) += plat_huk.c
 srcs-$(CFG_STM32MP1_SHARED_RESOURCES) += shared_resources.c
 srcs-$(CFG_TZC400) += plat_tzc400.c
 srcs-$(CFG_WITH_PAGER) += link_dummies_paged.c


### PR DESCRIPTION
This change implements generic function tee_otp_get_hw_unique_key() for
platform stm32mp1 to read device Hardware Unique Key from BSEC OTPs.

Location of HUK in BSEC OTPs is defined by configuration switches
CFG_STM32MP1_HUK_BSEC_BASE (BSEC word ID for HUK 1st bytes) and
CFG_STM32MP1_HUK_BSEC_COUNT (number of BSEC words defining HUK,
must be 4 as OP-TEE expects HUK is a 4 32bit words data).

CFG_STM32MP1_HUK_BSEC=y|n embeds or not the feature.
CFG_STM32MP1_HUK_BSEC_SHADOW_TESTKEY=y|n for using an all 0's test key.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
