### PR TITLE
Alternate proposal for https://github.com/OP-TEE/optee_os/pull/7183

### DIFF
--- a/core/drivers/crypto/caam/utils/utils_dmaobj.c
+++ b/core/drivers/crypto/caam/utils/utils_dmaobj.c
@@ -386,7 +386,7 @@ static TEE_Result check_buffer_alignment(struct priv_dmaobj *priv,
 		}
 
 		va_start = (vaddr_t)entry->origbuf.data;
-		va_start_align = ROUNDUP(va_start, cacheline_size);
+		va_start_align = ROUNDUP2(va_start, cacheline_size);
 
 		if (va_start_align != va_start) {
 			DMAOBJ_TRACE("Start 0x%" PRIxVA " vs align 0x%" PRIxVA,
@@ -443,13 +443,13 @@ static TEE_Result check_buffer_alignment(struct priv_dmaobj *priv,
 		}
 
 		va_end = (vaddr_t)entry->origbuf.data + entry->origbuf.length;
-		va_end_align = ROUNDUP(va_end, cacheline_size);
+		va_end_align = ROUNDUP2(va_end, cacheline_size);
 
 		if (va_end != va_end_align) {
 			DMAOBJ_TRACE("End 0x%" PRIxVA " vs align 0x%" PRIxVA,
 				     va_end, va_end_align);
 
-			va_end_align = ROUNDDOWN(va_end, cacheline_size);
+			va_end_align = ROUNDDOWN2(va_end, cacheline_size);
 			remlen = entry->origbuf.length - va_end_align;
 
 			if (remlen <= cacheline_size) {
@@ -1296,7 +1296,7 @@ TEE_Result caam_dmaobj_sgtbuf_build(struct caamdmaobj *obj, size_t *length,
 	max_length = *length;
 	if (priv->dmabuf.allocated && max_length > priv->dmabuf.allocated &&
 	    priv->dmabuf.allocated > align)
-		max_length = ROUNDDOWN(priv->dmabuf.allocated, align);
+		max_length = ROUNDDOWN2(priv->dmabuf.allocated, align);
 
 	DMAOBJ_TRACE("Prepare SGT/Buffer to do %zu of %zu", max_length,
 		     *length);

--- a/core/drivers/crypto/caam/utils/utils_mem.c
+++ b/core/drivers/crypto/caam/utils/utils_mem.c
@@ -50,7 +50,8 @@ static void *mem_alloc(size_t size, uint8_t type)
 				     &alloc_size))
 			return NULL;
 
-		if (ROUNDUP_OVERFLOW(alloc_size, cacheline_size, &alloc_size))
+		if (ROUNDUP_OVERFLOW_VAR(alloc_size, cacheline_size,
+					 &alloc_size))
 			return NULL;
 
 		ptr = memalign(cacheline_size, alloc_size);

--- a/core/drivers/crypto/stm32/stm32_cryp.c
+++ b/core/drivers/crypto/stm32/stm32_cryp.c
@@ -1122,7 +1122,7 @@ TEE_Result stm32_cryp_update(struct stm32_cryp_context *ctx, bool last_block,
 	 */
 	if (last_block && algo_mode_is_ecb_cbc(ctx->cr) &&
 	    is_encrypt(ctx->cr) &&
-	    (ROUNDDOWN(data_size, ctx->block_u32 * sizeof(uint32_t)) !=
+	    (ROUNDDOWN2(data_size, ctx->block_u32 * sizeof(uint32_t)) !=
 	     data_size)) {
 		if (data_size < ctx->block_u32 * sizeof(uint32_t) * 2) {
 			/*

--- a/core/kernel/tee_misc.c
+++ b/core/kernel/tee_misc.c
@@ -126,7 +126,7 @@ void *alloc_cache_aligned(size_t size)
 	uint32_t cacheline_size = 0;
 
 	cacheline_size = cache_get_max_line_size();
-	if (ROUNDUP_OVERFLOW(size, cacheline_size, &alloc_size))
+	if (ROUNDUP_OVERFLOW_VAR(size, cacheline_size, &alloc_size))
 		return NULL;
 
 	ptr = memalign(cacheline_size, alloc_size);

--- a/core/kernel/transfer_list.c
+++ b/core/kernel/transfer_list.c
@@ -390,9 +390,7 @@ bool transfer_list_set_data_size(struct transfer_list_header *tl,
 		 * of TL
 		 */
 		mov_dis = new_ev - old_ev;
-		if (ROUNDUP_OVERFLOW(mov_dis,
-				     TL_ALIGNMENT_FROM_ORDER(tl->alignment),
-				     &mov_dis) ||
+		if (ROUNDUP_OVERFLOW_VAR(mov_dis, align, &mov_dis) ||
 		    tl->size + mov_dis > tl->max_size) {
 			return false;
 		}

--- a/core/kernel/transfer_list.c
+++ b/core/kernel/transfer_list.c
@@ -360,6 +360,7 @@ bool transfer_list_set_data_size(struct transfer_list_header *tl,
 	size_t gap = 0;
 	size_t mov_dis = 0;
 	size_t sz = 0;
+	size_t align = 0;
 
 	if (!tl || !tl_e)
 		return false;
@@ -380,6 +381,7 @@ bool transfer_list_set_data_size(struct transfer_list_header *tl,
 	    ROUNDUP_OVERFLOW(new_ev, TRANSFER_LIST_GRANULE, &new_ev))
 		return false;
 
+	align = TL_ALIGNMENT_FROM_ORDER(tl->alignment);
 	if (new_ev > old_ev) {
 		/*
 		 * Move distance should be rounded up to match the entry data
@@ -401,8 +403,7 @@ bool transfer_list_set_data_size(struct transfer_list_header *tl,
 		 * Move distance should be rounded down to match the entry data
 		 * alignment.
 		 */
-		mov_dis = ROUNDDOWN(old_ev - new_ev,
-				    TL_ALIGNMENT_FROM_ORDER(tl->alignment));
+		mov_dis = ROUNDDOWN2(old_ev - new_ev, align);
 		r_new_ev = old_ev - mov_dis;
 		tl->size -= mov_dis;
 	}
@@ -537,7 +538,7 @@ transfer_list_add_with_align(struct transfer_list_header *tl, uint16_t tag_id,
 		 * alignment. Fill the gap with an empty transfer entry as a
 		 * placeholder before adding the desired transfer entry
 		 */
-		new_tl_ev = ROUNDUP(ev, TL_ALIGNMENT_FROM_ORDER(alignment)) -
+		new_tl_ev = ROUNDUP2(ev, TL_ALIGNMENT_FROM_ORDER(alignment)) -
 			    sizeof(struct transfer_list_entry);
 		assert(new_tl_ev - tl_ev > sizeof(struct transfer_list_entry));
 		dummy_te_data_sz = new_tl_ev - tl_ev -

--- a/core/mm/boot_mem.c
+++ b/core/mm/boot_mem.c
@@ -51,7 +51,7 @@ static void *mem_alloc_tmp(struct boot_mem_desc *desc, size_t len, size_t align)
 	assert(IS_POWER_OF_TWO(align) && !(len % align));
 	if (SUB_OVERFLOW(desc->mem_end, len, &va))
 		panic();
-	va = ROUNDDOWN(va, align);
+	va = ROUNDDOWN2(va, align);
 	if (va < desc->mem_start)
 		panic();
 	desc->mem_end = va;
@@ -66,7 +66,7 @@ static void *mem_alloc(struct boot_mem_desc *desc, size_t len, size_t align)
 	runtime_assert(!IS_ENABLED(CFG_WITH_PAGER));
 	assert(desc && desc->mem_start && desc->mem_end);
 	assert(IS_POWER_OF_TWO(align) && !(len % align));
-	va = ROUNDUP(desc->mem_start, align);
+	va = ROUNDUP2(desc->mem_start, align);
 	if (ADD_OVERFLOW(va, len, &ve))
 		panic();
 	if (ve > desc->mem_end)

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1288,7 +1288,7 @@ static bool assign_mem_va_dir(vaddr_t tee_ram_va, struct memory_map *mem_map,
 
 			if (SUB_OVERFLOW(va, map->size, &va))
 				return false;
-			va = ROUNDDOWN(va, map->region_size);
+			va = ROUNDDOWN2(va, map->region_size);
 			/*
 			 * Make sure that va is aligned with pa for
 			 * efficient pgdir mapping. Basically pa &
@@ -2224,8 +2224,8 @@ TEE_Result core_mmu_remove_mapping(enum teecore_memtypes type, void *addr,
 	i = map - static_memory_map.map;
 
 	/* Check that we have a full match */
-	p = ROUNDDOWN(pa, granule);
-	l = ROUNDUP(len + pa - p, granule);
+	p = ROUNDDOWN2(pa, granule);
+	l = ROUNDUP2(len + pa - p, granule);
 	if (map->pa != p || map->size != l)
 		return TEE_ERROR_GENERIC;
 
@@ -2301,8 +2301,8 @@ void *core_mmu_add_mapping(enum teecore_memtypes type, paddr_t addr, size_t len)
 		return NULL;
 
 	granule = BIT64(tbl_info.shift);
-	p = ROUNDDOWN(addr, granule);
-	l = ROUNDUP(len + addr - p, granule);
+	p = ROUNDDOWN2(addr, granule);
+	l = ROUNDUP2(len + addr - p, granule);
 
 	/* Ban overflowing virtual addresses */
 	if (map->size < l)
@@ -2709,12 +2709,12 @@ void core_mmu_init_phys_mem(void)
 		 * The VCORE macros are relocatable so we need to translate
 		 * the addresses now that the MMU is enabled.
 		 */
-		end_pa = vaddr_to_phys(ROUNDUP(VCORE_FREE_END_PA,
-					       align) - 1) + 1;
+		end_pa = vaddr_to_phys(ROUNDUP2(VCORE_FREE_END_PA, align) - 1) +
+			 1;
 		/* Carve out the part used by OP-TEE core */
 		carve_out_core_mem(vaddr_to_phys(VCORE_UNPG_RX_PA), end_pa);
 		if (IS_ENABLED(CFG_CORE_SANITIZE_KADDRESS)) {
-			pa = vaddr_to_phys(ROUNDUP(ASAN_MAP_PA, align));
+			pa = vaddr_to_phys(ROUNDUP2(ASAN_MAP_PA, align));
 			carve_out_core_mem(pa, pa + ASAN_MAP_SZ);
 		}
 

--- a/core/mm/core_mmu.c
+++ b/core/mm/core_mmu.c
@@ -1320,7 +1320,7 @@ static bool assign_mem_va_dir(vaddr_t tee_ram_va, struct memory_map *mem_map,
 					return false;
 			}
 
-			if (ROUNDUP_OVERFLOW(va, map->region_size, &va))
+			if (ROUNDUP_OVERFLOW_VAR(va, map->region_size, &va))
 				return false;
 			/*
 			 * Make sure that va is aligned with pa for

--- a/core/mm/tee_mm.c
+++ b/core/mm/tee_mm.c
@@ -45,9 +45,9 @@ bool tee_mm_init(tee_mm_pool_t *pool, paddr_t lo, paddr_size_t size,
 	if (pool == NULL)
 		return false;
 
-	lo = ROUNDUP(lo, 1 << shift);
+	lo = ROUNDUP2(lo, 1 << shift);
 	rounded = lo - initial_lo;
-	size = ROUNDDOWN(size - rounded, 1 << shift);
+	size = ROUNDDOWN2(size - rounded, 1 << shift);
 
 	assert(((uint64_t)size >> shift) < (uint64_t)UINT32_MAX);
 

--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -1178,7 +1178,8 @@ static TEE_Result tee_mmu_user_va2pa_attr(const struct user_mode_ctx *uctx,
 			assert(!granule || IS_POWER_OF_TWO(granule));
 
 			offset = region->offset +
-				 ROUNDDOWN((vaddr_t)ua - region->va, granule);
+				 ROUNDDOWN2((vaddr_t)ua - region->va,
+					    granule);
 
 			res = mobj_get_pa(region->mobj, offset, granule, &p);
 			if (res != TEE_SUCCESS)
@@ -1270,7 +1271,8 @@ TEE_Result vm_check_access_rights(const struct user_mode_ctx *uctx,
 	   !vm_buf_is_inside_um_private(uctx, (void *)uaddr, len))
 		return TEE_ERROR_ACCESS_DENIED;
 
-	for (a = ROUNDDOWN(uaddr, addr_incr); a < end_addr; a += addr_incr) {
+	for (a = ROUNDDOWN2(uaddr, addr_incr); a < end_addr;
+	     a += addr_incr) {
 		uint32_t attr;
 		TEE_Result res;
 

--- a/core/mm/vm.c
+++ b/core/mm/vm.c
@@ -75,7 +75,7 @@ static vaddr_t select_va_in_range(const struct vm_region *prev_reg,
 	if (ADD_OVERFLOW(prev_reg->va, prev_reg->size, &begin_va) ||
 	    ADD_OVERFLOW(begin_va, pad_begin, &begin_va) ||
 	    ADD_OVERFLOW(begin_va, pad, &begin_va) ||
-	    ROUNDUP_OVERFLOW(begin_va, granul, &begin_va))
+	    ROUNDUP_OVERFLOW_VAR(begin_va, granul, &begin_va))
 		return 0;
 
 	if (reg->va) {
@@ -97,7 +97,7 @@ static vaddr_t select_va_in_range(const struct vm_region *prev_reg,
 	if (ADD_OVERFLOW(begin_va, reg->size, &end_va) ||
 	    ADD_OVERFLOW(end_va, pad_end, &end_va) ||
 	    ADD_OVERFLOW(end_va, pad, &end_va) ||
-	    ROUNDUP_OVERFLOW(end_va, granul, &end_va))
+	    ROUNDUP_OVERFLOW_VAR(end_va, granul, &end_va))
 		return 0;
 
 	if (end_va <= next_reg->va) {

--- a/ldelf/ta_elf.c
+++ b/ldelf/ta_elf.c
@@ -962,10 +962,10 @@ static void parse_property_segment(struct ta_elf *elf)
 	    !IS_POWER_OF_TWO(align))
 		return;
 
-	desc_offset = ROUNDUP(sizeof(*note) + sizeof(ELF_NOTE_GNU), align);
+	desc_offset = ROUNDUP2(sizeof(*note) + sizeof(ELF_NOTE_GNU), align);
 
 	if (desc_offset > elf->prop_memsz ||
-	    ROUNDUP(desc_offset + note->n_descsz, align) > elf->prop_memsz)
+	    ROUNDUP2(desc_offset + note->n_descsz, align) > elf->prop_memsz)
 		return;
 
 	desc = (char *)(va + desc_offset);
@@ -992,7 +992,8 @@ static void parse_property_segment(struct ta_elf *elf)
 			}
 		}
 
-		prop_offset += ROUNDUP(sizeof(*prop) + prop->pr_datasz, align);
+		prop_offset += ROUNDUP2(sizeof(*prop) + prop->pr_datasz,
+					   align);
 	} while (prop_offset < note->n_descsz);
 }
 

--- a/lib/libutee/tee_api.c
+++ b/lib/libutee/tee_api.c
@@ -133,7 +133,7 @@ static TEE_Result map_tmp_param(struct utee_params *up, void **tmp_buf,
 			if (b && s &&
 			    !TEE_CheckMemoryAccessRights(flags, b, s)) {
 				is_tmp_mem[n] = true;
-				tbl += ROUNDUP(s, tmp_align);
+				tbl += ROUNDUP2(s, tmp_align);
 			}
 			break;
 		default:
@@ -159,7 +159,7 @@ static TEE_Result map_tmp_param(struct utee_params *up, void **tmp_buf,
 			s = up->vals[n * 2 + 1];
 			b = (void *)(vaddr_t)up->vals[n * 2];
 			tmp_va[n] = tb;
-			tb += ROUNDUP(s, tmp_align);
+			tb += ROUNDUP2(s, tmp_align);
 			up->vals[n * 2] = (vaddr_t)tmp_va[n];
 			if (TEE_PARAM_TYPE_GET(up->types, n) !=
 			    TEE_PARAM_TYPE_MEMREF_OUTPUT)

--- a/lib/libutee/tee_api_operations.c
+++ b/lib/libutee/tee_api_operations.c
@@ -1115,8 +1115,8 @@ static TEE_Result tee_buffer_update(
 	/* If we can feed from buffer */
 	if ((op->buffer_offs > 0) &&
 	    ((op->buffer_offs + slen) >= (buffer_size + buffer_left))) {
-		l = ROUNDUP(op->buffer_offs + slen - buffer_size,
-				op->block_size);
+		l = ROUNDUP2(op->buffer_offs + slen - buffer_size,
+			     op->block_size);
 		l = MIN(op->buffer_offs, l);
 		/*
 		 * If we're buffering only a single block, process it
@@ -1146,9 +1146,9 @@ static TEE_Result tee_buffer_update(
 	if (slen >= (buffer_size + buffer_left)) {
 		/* Buffer is empty, feed as much as possible from src */
 		if (op->buffer_two_blocks)
-			l = ROUNDUP(slen - buffer_size, op->block_size);
+			l = ROUNDUP2(slen - buffer_size, op->block_size);
 		else
-			l = ROUNDUP(slen - buffer_size + 1, op->block_size);
+			l = ROUNDUP2(slen - buffer_size + 1, op->block_size);
 
 		tmp_dlen = dlen;
 		res = update_func(op->state, src, l, dst, &tmp_dlen);
@@ -1216,7 +1216,7 @@ TEE_Result TEE_CipherUpdate(TEE_OperationHandle operation, const void *srcData,
 		    operation->block_size * 2) {
 			req_dlen = operation->buffer_offs + srcLen -
 				   operation->block_size * 2;
-			req_dlen = ROUNDUP(req_dlen, operation->block_size);
+			req_dlen = ROUNDUP2(req_dlen, operation->block_size);
 		} else {
 			req_dlen = 0;
 		}
@@ -1694,8 +1694,8 @@ static TEE_Result ae_update_helper(TEE_OperationHandle operation,
 	 * can't restore sync with this API.
 	 */
 	if (operation->block_size > 1) {
-		req_dlen = ROUNDDOWN(operation->buffer_offs + slen,
-				     operation->block_size);
+		req_dlen = ROUNDDOWN2(operation->buffer_offs + slen,
+				      operation->block_size);
 	} else {
 		req_dlen = slen;
 	}

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -49,10 +49,14 @@
 #endif
 
 #ifndef __ASSEMBLER__
-/* Round up the even multiple of size, size has to be a multiple of 2 */
+/* Round up the even multiple of size, size has to be a power of 2 */
 #define ROUNDUP(v, size) (((v) + ((__typeof__(v))(size) - 1)) & \
 			  ~((__typeof__(v))(size) - 1))
 
+/*
+ * Round up the even multiple of size and return if result overflow
+ * output value range. Size has to be a power of 2.
+ */
 #define ROUNDUP_OVERFLOW(v, size, res) (__extension__({ \
 	typeof(*(res)) __roundup_tmp = 0; \
 	typeof(v) __roundup_mask = (typeof(v))(size) - 1; \
@@ -63,7 +67,7 @@
 
 /*
  * Rounds up to the nearest multiple of y and then divides by y. Safe
- * against overflow, y has to be a multiple of 2.
+ * against overflow, y has to be a power of 2.
  *
  * This macro is intended to be used to convert from "number of bytes" to
  * "number of pages" or similar units. Example:
@@ -76,7 +80,7 @@
 	(__roundup_x / (y)) + (__roundup_x & __roundup_mask ? 1 : 0); \
 }))
 
-/* Round down the even multiple of size, size has to be a multiple of 2 */
+/* Round down the even multiple of size, size has to be a power of 2 */
 #define ROUNDDOWN(v, size) ((v) & ~((__typeof__(v))(size) - 1))
 
 /*

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -9,6 +9,7 @@
 #include <inttypes.h>
 
 #ifndef __ASSEMBLER__
+#include <assert.h>
 #include <stddef.h>
 #endif
 
@@ -77,6 +78,7 @@
 	typeof(x) __roundup_x = (x); \
 	typeof(y) __roundup_mask = (typeof(x))(y) - 1; \
 	\
+	assert(IS_POWER_OF_TWO(y)); \
 	(__roundup_x / (y)) + (__roundup_x & __roundup_mask ? 1 : 0); \
 }))
 

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -50,22 +50,33 @@
 #endif
 
 #ifndef __ASSEMBLER__
-/* Round up the even multiple of size, size has to be a power of 2 */
-#define ROUNDUP(v, size) (((v) + ((__typeof__(v))(size) - 1)) & \
-			  ~((__typeof__(v))(size) - 1))
-
 /*
+ * __ROUNDUP(v, size)
+ * ROUNDUP(v, size)
  * ROUNDUP_VAR(v, size)
  * Round up value @v to the even multiple of @size that shall be a power of 2.
+ *
+ * __ROUNDOWN() does not verify @size is a power of 2.
+ *
+ * ROUNDUP() requires a constant value as @size argument.
+ * If @size is not a power of 2, the macro evaluates as unexpected void.
  *
  * ROUNDUP_VAR() supports a variable reference as @size argument.
  * The macro asserts (in debug mode) that @size is a power of 2.
  */
+#define __ROUNDUP(v, size) \
+	(((v) + ((__typeof__(v))(size) - 1)) & ~((__typeof__(v))(size) - 1))
+
 #define ROUNDUP_VAR(v, size) \
 	(__extension__({ \
 		assert(IS_POWER_OF_TWO(size)); \
-		ROUNDUP((v), (size)); \
+		__ROUNDUP((v), (size)); \
 	}))
+
+#define ROUNDUP(v, size) \
+	(__builtin_choose_expr(IS_POWER_OF_TWO((size)), \
+			       __ROUNDUP((v), (size)), \
+			       (void)0))
 
 /*
  * ROUNDUP2(v, size)

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -207,11 +207,11 @@
 	(__extension__ ({ __typeof__(x) _x = (x); \
 	  __typeof__(y) _y = (y); \
 	  (_x + (_y / 2)) / _y; }))
-#else
+#else /* __ASSEMBLER__ */
 #define ROUNDUP(x, y)			((((x) + (y) - 1) / (y)) * (y))
-#define ROUNDDOWN(x, y)		(((x) / (y)) * (y))
+#define ROUNDDOWN(x, y)			(((x) / (y)) * (y))
 #define UDIV_ROUND_NEAREST(x, y)	(((x) + ((y) / 2)) / (y))
-#endif
+#endif /* __ASSEMBLER__ */
 
 /* x has to be of an unsigned type */
 #define IS_POWER_OF_TWO(x) (((x) != 0) && (((x) & (~(x) + 1)) == (x)))

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -68,6 +68,14 @@
 	}))
 
 /*
+ * ROUNDUP2(v, size)
+ *
+ * Round up value @v to the even multiple of @size.
+ * @size can have any value.
+ */
+#define ROUNDUP2(v, size)	((((v) + (size) - 1) / (size)) * (size))
+
+/*
  * Round up the even multiple of size and return if result overflow
  * output value range. Size has to be a power of 2.
  */
@@ -94,6 +102,27 @@
 	(__extension__({ \
 		assert(IS_POWER_OF_TWO(size)); \
 		ROUNDUP_OVERFLOW((v), (size), (res)); \
+	}))
+
+/*
+ * ROUNDUP_OVERFLOW2(v, size, res)
+ *
+ * Round up value @v to the even multiple of @size and return if result
+ * overflows the output value range pointed by @res. The rounded value is
+ * stored in the memory address pointed by @res.
+ * @size can have any value.
+ */
+#define ROUNDUP_OVERFLOW2(v, size, res) \
+	(__extension__({ \
+		typeof(*(res)) __roundup_tmp = 0; \
+		typeof(v) __roundup_mod = 0; \
+		typeof(v) __roundup_add = 0; \
+		\
+		__roundup_mod = (v) % (typeof(v))(size); \
+		if (__roundup_mod) \
+			__roundup_add = (typeof(v))(size) - __roundup_mod; \
+		ADD_OVERFLOW((v), __roundup_add, &__roundup_tmp) ? 1 : \
+			((void)(*(res) = __roundup_tmp), 0); \
 	}))
 
 /*
@@ -127,6 +156,14 @@
 		assert(IS_POWER_OF_TWO(size)); \
 		ROUNDDOWN((v), (size)); \
 	}))
+
+/*
+ * ROUNDDOWN2(v, size)
+
+ * Round down value @v to the even multiple of @size.
+ * @sizee can have any value.
+ */
+#define ROUNDDOWN2(v, size)	(((v) / (size)) * (size))
 
 /*
  * Round up the result of x / y to the nearest upper integer if result is not 

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -197,7 +197,7 @@
 #define ROUNDDOWN2(v, size)	(((v) / (size)) * (size))
 
 /*
- * Round up the result of x / y to the nearest upper integer if result is not 
+ * Round up the result of x / y to the nearest upper integer if result is not
  * already an integer.
  */
 #define DIV_ROUND_UP(x, y) (((x) + (y) - 1) / (y))

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -55,6 +55,19 @@
 			  ~((__typeof__(v))(size) - 1))
 
 /*
+ * ROUNDUP_VAR(v, size)
+ * Round up value @v to the even multiple of @size that shall be a power of 2.
+ *
+ * ROUNDUP_VAR() supports a variable reference as @size argument.
+ * The macro asserts (in debug mode) that @size is a power of 2.
+ */
+#define ROUNDUP_VAR(v, size) \
+	(__extension__({ \
+		assert(IS_POWER_OF_TWO(size)); \
+		ROUNDUP((v), (size)); \
+	}))
+
+/*
  * Round up the even multiple of size and return if result overflow
  * output value range. Size has to be a power of 2.
  */
@@ -65,6 +78,23 @@
 	ADD_OVERFLOW((v), __roundup_mask, &__roundup_tmp) ? 1 : \
 		((void)(*(res) = __roundup_tmp & ~__roundup_mask), 0); \
 }))
+
+/*
+ * ROUNDUP_OVERFLOW_VAR(v, size)
+ *
+ * Round up value @v to the even multiple of @size and return if result
+ * overflows the output value range pointed by @res. The rounded value is
+ * stored in the memory address pointed by @res.
+ * @size must be a power of 2.
+ *
+ * ROUNDUP_OVERFLOW_VAR() supports a variable reference as @size argument.
+ * The macro asserts (in debug mode) that @size is a power of 2.
+ */
+#define ROUNDUP_OVERFLOW_VAR(v, size, res) \
+	(__extension__({ \
+		assert(IS_POWER_OF_TWO(size)); \
+		ROUNDUP_OVERFLOW((v), (size), (res)); \
+	}))
 
 /*
  * Rounds up to the nearest multiple of y and then divides by y. Safe
@@ -84,6 +114,19 @@
 
 /* Round down the even multiple of size, size has to be a power of 2 */
 #define ROUNDDOWN(v, size) ((v) & ~((__typeof__(v))(size) - 1))
+
+/*
+ * ROUNDDOWN_VAR(v, size)
+ * Round down value @v to the even multiple of @size that shall be a power of 2.
+ *
+ * ROUNDDOWN_VAR() supports a variable reference as @size argument.
+ * The macro asserts (in debug mode) that @size is a power of 2.
+ */
+#define ROUNDDOWN_VAR(v, size)	\
+	(__extension__({ \
+		assert(IS_POWER_OF_TWO(size)); \
+		ROUNDDOWN((v), (size)); \
+	}))
 
 /*
  * Round up the result of x / y to the nearest upper integer if result is not 

--- a/lib/libutils/ext/include/util.h
+++ b/lib/libutils/ext/include/util.h
@@ -152,20 +152,31 @@
 	(__roundup_x / (y)) + (__roundup_x & __roundup_mask ? 1 : 0); \
 }))
 
-/* Round down the even multiple of size, size has to be a power of 2 */
-#define ROUNDDOWN(v, size) ((v) & ~((__typeof__(v))(size) - 1))
-
 /*
+ * __ROUNDOWN(v, size)
+ * ROUNDDOWN(v, size)
  * ROUNDDOWN_VAR(v, size)
  * Round down value @v to the even multiple of @size that shall be a power of 2.
+ *
+ * __ROUNDOWN() does not verify @size is a power of 2.
+ *
+ * ROUNDDOWN() requires a constant value as @size argument.
+ * If @size is not a power of 2, the macro evaluates as unexpected void.
  *
  * ROUNDDOWN_VAR() supports a variable reference as @size argument.
  * The macro asserts (in debug mode) that @size is a power of 2.
  */
+#define __ROUNDDOWN(v, size)	((v) & ~((__typeof__(v))(size) - 1)) \
+
+#define ROUNDDOWN(v, size) \
+	(__builtin_choose_expr(IS_POWER_OF_TWO((size)), \
+			       __ROUNDDOWN((v), (size)), \
+			       (void)0))
+
 #define ROUNDDOWN_VAR(v, size)	\
 	(__extension__({ \
 		assert(IS_POWER_OF_TWO(size)); \
-		ROUNDDOWN((v), (size)); \
+		__ROUNDDOWN((v), (size)); \
 	}))
 
 /*


### PR DESCRIPTION
Alternate proposal for OP-TEE OS P-R 7183 to enforce `ROUNDUP()` and `ROUNDDOWN()` size argument is a power of 2:

- Add `ROUNDUP_VAR()`, `ROUNDDOWN_VAR()` and `ROUNDUP_OVERFLOW_VAR()` for known constant size argument cases.
  I'm not sure `ROUNDUP_OVERFLOW_VAR()` is really useful.
- Add `ROUNDUP2()`, `ROUNDDOWN2()` and `ROUNDUP_OVERFLOW2'()` for rounding with possibly non-power-of-2 size argument.
- Preserve all use of `ROUNDUP()` and `ROUDNDOWN()` for known size argumen.
- Change implementation using a not known size argument to use `ROUND{UP|DOWN}2()` (seems to have better impact than `ROUNDxx_VAR()` or `ROUNDUP_OVERFLOW_VAR()`.